### PR TITLE
Replace mvn publish with mvn plugin to fix optional scope in pom file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
 buildscript {
     ext {
         spring_boot_version = '1.5.9.RELEASE'
+        depedency_management_version = '1.0.4.RELEASE'
         elasticache_client_version = '1.1.1'
         commons_logging_version = '1.2'
+        testcontainers_version = '1.6.0'
     }
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:$spring_boot_version")
+        classpath("io.spring.gradle:dependency-management-plugin:$depedency_management_version")
         classpath("io.spring.gradle:propdeps-plugin:0.0.9.RELEASE")
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3")
         classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1")
@@ -38,15 +40,9 @@ allprojects {
 subprojects {
     apply from: JAVA_GRADLE
     apply from: RELEASE_GRADLE
-    apply plugin: 'org.springframework.boot'
     apply plugin: 'propdeps'
-    apply plugin: 'propdeps-maven'
-    apply plugin: 'propdeps-idea'
     apply plugin: 'propdeps-eclipse'
-
-    bootRepackage {
-        enabled false
-    }
+    apply plugin: 'io.spring.dependency-management'
 
     task sourcesJar(type: Jar, dependsOn: classes) {
         classifier = 'sources'
@@ -56,11 +52,6 @@ subprojects {
     task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier = 'javadoc'
         from javadoc.destinationDir
-    }
-
-    artifacts {
-        archives sourcesJar
-        archives javadocJar
     }
 
     jar {
@@ -76,9 +67,13 @@ subprojects {
     }
 
     dependencyManagement {
+        imports {
+            mavenBom "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
+        }
         dependencies {
             dependency "com.amazonaws:elasticache-java-cluster-client:$elasticache_client_version"
             dependency "commons-logging:commons-logging:$commons_logging_version"
+            dependency "org.testcontainers:testcontainers:$testcontainers_version"
         }
     }
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,48 +1,32 @@
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'maven-publish'
+apply plugin: 'propdeps-maven'
 
-ext.pomConfig = {
-    licenses {
-        license {
-            name "The Apache Software License, Version 2.0"
-            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            distribution "repo"
-        }
-    }
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                licenses {
+                    license {
+                        name "The Apache Software License, Version 2.0"
+                        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution "repo"
+                    }
+                }
 
-    scm {
-        url "https://github.com/sixhours-team/memcached-spring-boot.git"
-    }
+                scm {
+                    url "https://github.com/sixhours-team/memcached-spring-boot.git"
+                }
 
-    developers {
-        developer {
-            name 'Igor Bolic'
-            email 'igor.bolic@sixhours.io'
-        }
-        developer {
-            name 'Sasa Bolic'
-            email 'sasa.bolic@sixhours.io'
-        }
-    }
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-
-            artifact sourcesJar
-
-            if (file('src/main').exists()) {
-                artifact javadocJar
-            }
-
-            pom.withXml {
-                def root = asNode()
-                root.appendNode('name', "${project.projectName}")
-                root.appendNode('description', "${project.projectDesc}")
-                root.appendNode('url', 'https://github.com/sixhours-team/memcached-spring-boot')
-                root.children().last() + pomConfig
+                developers {
+                    developer {
+                        name 'Igor Bolic'
+                        email 'igor.bolic@sixhours.io'
+                    }
+                    developer {
+                        name 'Sasa Bolic'
+                        email 'sasa.bolic@sixhours.io'
+                    }
+                }
             }
         }
     }
@@ -51,7 +35,7 @@ publishing {
 bintray {
     user = System.getenv('BINTRAY_USER')
     key = System.getenv('BINTRAY_KEY')
-    publications = ['mavenJava']
+    configurations = ['archives']
     pkg {
         repo = 'maven'
         userOrg = 'sixhours-team'

--- a/memcached-spring-boot-autoconfigure/build.gradle
+++ b/memcached-spring-boot-autoconfigure/build.gradle
@@ -3,6 +3,11 @@ ext.projectDesc = 'Memcached Spring Boot AutoConfiguration'
 
 apply from: SONAR_GRADLE
 
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
 dependencies {
     compile('org.springframework.boot:spring-boot-autoconfigure')
 
@@ -12,7 +17,7 @@ dependencies {
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testCompile('commons-logging:commons-logging')
 
-    integrationTestCompile('org.testcontainers:testcontainers:1.4.3')
+    integrationTestCompile('org.testcontainers:testcontainers')
 }
 
 compileJava.dependsOn(processResources)

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedAutoConfigurationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedAutoConfigurationTest.java
@@ -212,7 +212,7 @@ public class MemcachedAutoConfigurationTest {
     @Test
     public void whenCustomConfigurationThenMemcachedLoaded() {
         loadContext(CacheConfiguration.class, "memcached.cache.servers=192.168.99.100:11212",
-                "memcached.cache.mode=dynamic",
+                "memcached.cache.mode=static",
                 "memcached.cache.expiration=3600",
                 "memcached.cache.prefix=custom:prefix",
                 "memcached.cache.namespace=custom_namespace");
@@ -221,7 +221,7 @@ public class MemcachedAutoConfigurationTest {
 
         MemcachedClient memcachedClient = (MemcachedClient) ReflectionTestUtils.getField(memcachedCacheManager, "memcachedClient");
 
-        assertMemcachedClient(memcachedClient, ClientMode.Dynamic, new InetSocketAddress("192.168.99.100", 11212));
+        assertMemcachedClient(memcachedClient, ClientMode.Static, new InetSocketAddress("192.168.99.100", 11212));
         assertMemcachedCacheManager(memcachedCacheManager, 3600, "custom:prefix", "custom_namespace");
     }
 

--- a/memcached-spring-boot-starter/build.gradle
+++ b/memcached-spring-boot-starter/build.gradle
@@ -1,6 +1,10 @@
 ext.projectName = 'Memcached Spring Boot Starter'
 ext.projectDesc = 'Starter for the Memcached Spring Boot Cache'
 
+artifacts {
+    archives sourcesJar
+}
+
 dependencies {
     compile project(':memcached-spring-boot-autoconfigure')
     compile('com.amazonaws:elasticache-java-cluster-client')


### PR DESCRIPTION
Spring's dependency management plugin ignores optional declaration when generating pom file. Using the **Maven plugin** instead of **Maven publishing** plugin resolves the issue.