### PR TITLE
Deprecate namespace configuration property; use default value instead

### DIFF
--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheManager.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheManager.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentMap;
 public class MemcachedCacheManager implements CacheManager {
 
     private final ConcurrentMap<String, Cache> cacheMap = new ConcurrentHashMap<>();
+
     final MemcachedClient memcachedClient;
 
     private int expiration = Default.EXPIRATION;

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
@@ -19,6 +19,7 @@ import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ClientMode;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.util.StringUtils;
 
 import java.net.InetSocketAddress;
@@ -57,6 +58,7 @@ public class MemcachedCacheProperties {
     /**
      * Namespace key value used for invalidation of cached values. The default value is 'namespace'.
      */
+    @Deprecated
     private String namespace = Default.NAMESPACE;
 
     /**
@@ -105,12 +107,16 @@ public class MemcachedCacheProperties {
         this.prefix = prefix;
     }
 
+    @DeprecatedConfigurationProperty(reason = "As of release {@code 1.1.0}. To be removed in next major release. This " +
+            "value is expected to be retained only as a private value for the cache namespace. The namespace value used is 'namespace'")
     public String getNamespace() {
         return namespace;
     }
 
     public void setNamespace(String namespace) {
-        this.namespace = namespace;
+        if (namespace != null) {
+            this.namespace = Default.NAMESPACE;
+        }
     }
 
     public Protocol getProtocol() {

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/OnMissingSpringCacheType.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/OnMissingSpringCacheType.java
@@ -34,6 +34,5 @@ class OnMissingSpringCacheType extends NoneNestedConditions {
 
     @ConditionalOnProperty("spring.cache.type")
     static class SpringCacheType {
-
     }
 }

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedAutoConfigurationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedAutoConfigurationTest.java
@@ -251,7 +251,7 @@ public class MemcachedAutoConfigurationTest {
         MemcachedClient memcachedClient = (MemcachedClient) ReflectionTestUtils.getField(memcachedCacheManager, "memcachedClient");
 
         assertMemcachedClient(memcachedClient, ClientMode.Static, Default.PROTOCOL, new InetSocketAddress("192.168.99.100", 11212));
-        assertMemcachedCacheManager(memcachedCacheManager, 3600, "custom:prefix", "custom_namespace");
+        assertMemcachedCacheManager(memcachedCacheManager, 3600, "custom:prefix", Default.NAMESPACE);
     }
 
     @Test
@@ -263,7 +263,7 @@ public class MemcachedAutoConfigurationTest {
 
         MemcachedClient memcachedClient = (MemcachedClient) ReflectionTestUtils.getField(memcachedCacheManager, "memcachedClient");
 
-        assertMemcachedClient(memcachedClient, Default.CLIENT_MODE,  Default.PROTOCOL, new InetSocketAddress("192.168.99.100", 12345));
+        assertMemcachedClient(memcachedClient, Default.CLIENT_MODE, Default.PROTOCOL, new InetSocketAddress("192.168.99.100", 12345));
         assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, "custom:prefix", Default.NAMESPACE);
     }
 


### PR DESCRIPTION
This value is expected to be retained only as a private value for the cache namespace. The namespace value used is `Default.NAMESPACE` i.e. _"namespace"_.