### PR TITLE
Cache metrics

### DIFF
--- a/memcached-spring-boot-autoconfigure/build.gradle
+++ b/memcached-spring-boot-autoconfigure/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile('org.springframework.boot:spring-boot-autoconfigure')
 
     optional('org.springframework.boot:spring-boot-configuration-processor')
+    optional('org.springframework.boot:spring-boot-actuator')
     optional('org.springframework.cloud:spring-cloud-context')
     optional('com.amazonaws:elasticache-java-cluster-client')
 

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/ConditionalOnMissingRefreshScope.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/ConditionalOnMissingRefreshScope.java
@@ -26,7 +26,7 @@ import java.lang.annotation.*;
  *
  * @author Igor Bolic
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnMissingRefreshScopeCondition.class)

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfiguration.java
@@ -1,13 +1,35 @@
+/*
+ * Copyright 2017 Sixhours.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sixhours.memcached.cache;
 
 import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for the Memcached {@link CacheStatisticsProvider} bean.
+ *
+ * @author Igor Bolic
+ */
 @Configuration
 @AutoConfigureAfter(CacheAutoConfiguration.class)
 @ConditionalOnBean(MemcachedCacheManager.class)

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfiguration.java
@@ -1,0 +1,21 @@
+package io.sixhours.memcached.cache;
+
+import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigureAfter(CacheAutoConfiguration.class)
+@ConditionalOnBean(MemcachedCacheManager.class)
+@ConditionalOnClass(CacheStatisticsProvider.class)
+public class MemcachedCacheStatisticsAutoConfiguration {
+
+    @Bean
+    public MemcachedCacheStatisticsProvider memcachedCacheStatisticsProvider() {
+        return new MemcachedCacheStatisticsProvider();
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsProvider.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Sixhours.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sixhours.memcached.cache;
 
 import org.springframework.boot.actuate.cache.CacheStatistics;
@@ -5,6 +21,9 @@ import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
 import org.springframework.boot.actuate.cache.DefaultCacheStatistics;
 import org.springframework.cache.CacheManager;
 
+/**
+ * Memcached {@link CacheStatisticsProvider}.
+ */
 public class MemcachedCacheStatisticsProvider implements CacheStatisticsProvider<MemcachedCache> {
 
     @Override

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsProvider.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsProvider.java
@@ -1,0 +1,18 @@
+package io.sixhours.memcached.cache;
+
+import org.springframework.boot.actuate.cache.CacheStatistics;
+import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
+import org.springframework.boot.actuate.cache.DefaultCacheStatistics;
+import org.springframework.cache.CacheManager;
+
+public class MemcachedCacheStatisticsProvider implements CacheStatisticsProvider<MemcachedCache> {
+
+    @Override
+    public CacheStatistics getCacheStatistics(CacheManager cacheManager, MemcachedCache memcachedCache) {
+        DefaultCacheStatistics statistics = new DefaultCacheStatistics();
+
+        statistics.setGetCacheCounts(memcachedCache.hits(), memcachedCache.misses());
+
+        return statistics;
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/memcached-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=io.sixhours.memcached.cache.MemcachedCacheAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.sixhours.memcached.cache.MemcachedCacheAutoConfiguration,\
+io.sixhours.memcached.cache.MemcachedCacheStatisticsAutoConfiguration

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfigurationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfigurationTest.java
@@ -1,0 +1,162 @@
+package io.sixhours.memcached.cache;
+
+import net.spy.memcached.MemcachedClient;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.actuate.cache.CacheStatistics;
+import org.springframework.boot.actuate.cache.CacheStatisticsProvider;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+public class MemcachedCacheStatisticsAutoConfigurationTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+    private CacheManager cacheManager;
+
+    @After
+    public void tearDown() {
+        context.close();
+    }
+
+    @Test
+    public void whenCachingNotEnabledThenCacheStatisticsNotLoaded() {
+        loadContext(EmptyConfiguration.class);
+
+        thrown.expect(NoSuchBeanDefinitionException.class);
+        thrown.expectMessage("No bean named 'memcachedCacheStatisticsProvider' available");
+
+        this.context.getBean("memcachedCacheStatisticsProvider", CacheStatisticsProvider.class);
+    }
+
+    @Test
+    public void whenCacheTypeIsNoneThenCacheStatisticsNotLoaded() {
+        loadContext(CacheConfiguration.class, "spring.cache.type=none");
+
+        thrown.expect(NoSuchBeanDefinitionException.class);
+        thrown.expectMessage("No bean named 'memcachedCacheStatisticsProvider' available");
+
+        this.context.getBean("memcachedCacheStatisticsProvider", CacheStatisticsProvider.class);
+    }
+
+    @Test
+    public void whenNoCustomCacheManagerThenCacheStatisticsLoaded() {
+        loadContext(MemcachedAutoConfigurationTest.CacheConfiguration.class);
+
+        CacheStatisticsProvider provider = this.context.getBean("memcachedCacheStatisticsProvider", CacheStatisticsProvider.class);
+
+        assertThat(provider).isNotNull();
+    }
+
+    @Test
+    public void whenMemcachedCacheManagerBeanThenCacheStatisticsLoaded() {
+        loadContext(CacheWithMemcachedCacheManagerConfiguration.class);
+
+        CacheStatisticsProvider provider = this.context.getBean(
+                "memcachedCacheStatisticsProvider", CacheStatisticsProvider.class);
+
+        assertThat(provider).isNotNull();
+
+        this.cacheManager = this.context.getBean(CacheManager.class);
+        Cache books = this.cacheManager.getCache("books");
+
+        CacheStatistics cacheStatistics = provider.getCacheStatistics(this.cacheManager, books);
+
+        assertCacheStatistics(cacheStatistics, null, null);
+        getCacheKeyValues(books, "a", "b", "b", "c", "d", "c", "a", "a", "a", "d");
+
+        cacheStatistics = provider.getCacheStatistics(this.cacheManager, books);
+        assertCacheStatistics(cacheStatistics, 0.6d, 0.4d);
+    }
+
+    private void getCacheKeyValues(Cache cache, String... keys) {
+        for (String key : keys) {
+            cache.get(key);
+        }
+    }
+
+    private void assertCacheStatistics(CacheStatistics cacheStatistics, Double hitRatio, Double missRatio) {
+        assertThat(cacheStatistics).isNotNull();
+        assertRatio(hitRatio, cacheStatistics.getHitRatio());
+        assertRatio(missRatio, cacheStatistics.getMissRatio());
+    }
+
+    private static void assertRatio(Double actual, Double expected) {
+        if (actual == null || expected == null) {
+            assertThat(actual).isEqualTo(expected);
+        } else {
+            assertThat(actual).isEqualTo(expected, offset(0.01D));
+        }
+    }
+
+    private void loadContext(Class<?> configuration, String... environment) {
+        EnvironmentTestUtils.addEnvironment(context, environment);
+
+        context.register(configuration);
+        context.register(MemcachedCacheAutoConfiguration.class);
+        context.register(CacheAutoConfiguration.class);
+        context.register(MemcachedCacheStatisticsAutoConfiguration.class);
+        context.refresh();
+    }
+
+    @Configuration
+    static class EmptyConfiguration {
+    }
+
+    @Configuration
+    @EnableCaching
+    static class CacheConfiguration {
+    }
+
+    @Configuration
+    static class CacheWithCustomCacheManagerConfiguration extends CacheConfiguration {
+
+        @Bean
+        public CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager();
+        }
+    }
+
+    @Configuration
+    static class CacheWithMemcachedCacheManagerConfiguration extends CacheConfiguration {
+
+        @Bean
+        public MemcachedCacheManager cacheManager() {
+            MemcachedClient memcachedClient = mock(MemcachedClient.class);
+
+            given(memcachedClient.get(any()))
+                    .willReturn("namespace").willReturn(null)
+                    .willReturn("namespace").willReturn(null)
+                    .willReturn("namespace").willReturn("b")
+                    .willReturn("namespace").willReturn(null)
+                    .willReturn("namespace").willReturn(null)
+                    .willReturn("namespace").willReturn("c")
+                    .willReturn("namespace").willReturn("a")
+                    .willReturn("namespace").willReturn("a")
+                    .willReturn("namespace").willReturn("a")
+                    .willReturn("namespace").willReturn("d");
+
+            return new MemcachedCacheManager(memcachedClient);
+        }
+    }
+
+}

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfigurationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheStatisticsAutoConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Sixhours.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sixhours.memcached.cache;
 
 import net.spy.memcached.MemcachedClient;
@@ -24,6 +40,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Cache statistics auto-configuration tests.
+ *
+ * @author Igor Bolic
+ */
 public class MemcachedCacheStatisticsAutoConfigurationTest {
 
     @Rule

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheTest.java
@@ -84,6 +84,40 @@ public class MemcachedCacheTest {
     }
 
     @Test
+    public void whenLookupThenIncrementHits() {
+        when(memcachedClient.get(any())).thenReturn(NAMESPACE_KEY_VALUE).thenReturn(cachedValue);
+
+        assertThat(memcachedCache.hits()).isEqualTo(0);
+        assertThat(memcachedCache.misses()).isEqualTo(0);
+
+        memcachedCache.lookup(CACHED_OBJECT_KEY);
+
+        assertThat(memcachedCache.hits()).isEqualTo(1);
+        assertThat(memcachedCache.misses()).isEqualTo(0);
+
+        verify(memcachedClient).get(memcachedKey);
+        verify(memcachedClient).get(namespaceKey);
+        verifyNoMoreInteractions(memcachedClient);
+    }
+
+    @Test
+    public void whenLookupAndCacheValueMissingThenIncrementMisses() {
+        when(memcachedClient.get(any())).thenReturn(NAMESPACE_KEY_VALUE).thenReturn(null);
+
+        assertThat(memcachedCache.hits()).isEqualTo(0);
+        assertThat(memcachedCache.misses()).isEqualTo(0);
+
+        memcachedCache.lookup(CACHED_OBJECT_KEY);
+
+        assertThat(memcachedCache.hits()).isEqualTo(0);
+        assertThat(memcachedCache.misses()).isEqualTo(1);
+
+        verify(memcachedClient).get(memcachedKey);
+        verify(memcachedClient).get(namespaceKey);
+        verifyNoMoreInteractions(memcachedClient);
+    }
+
+    @Test
     public void whenGetNameThenReturnCacheName() {
         String actual = memcachedCache.getName();
 
@@ -92,7 +126,7 @@ public class MemcachedCacheTest {
 
     @Test
     public void whenGetNativeThenReturnMemcachedClient() {
-        Object actual = memcachedCache.getNativeCache();
+        MemcachedClient actual = memcachedCache.getNativeCache();
 
         assertThat(actual).isSameAs(memcachedClient);
     }


### PR DESCRIPTION
Cache metrics for the Spring Boot Actuator. Provides hits & misses ratio for the Spring Boot application. Works with Spring Boot 1.5.x. Future release will support new metrics in Spring Boot 2.0.0.

Resolves #37