### PR TITLE
Artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: java
 sudo: required
 services:
   - docker
-jdk:
-  - openjdk8
-  - openjdk11
+jobs:
+  include:
+    - jdk: openjdk8
+      env: BUILD_PUBLISH=true
+    - jdk: openjdk11
+      env: BUILD_PUBLISH=false
+    - jdk: openjdk13
+      env: BUILD_PUBLISH=false
 script: ./travisBuild.sh
 after_success:
   - ./sonarcloud.sh

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ ext.SONAR_GRADLE = "$rootDir/gradle/sonar.gradle"
 
 ext {
     projectVersion = '2.0.0-SNAPSHOT'
+    useLastTag = false
 }
 
 allprojects {
@@ -36,10 +37,9 @@ allprojects {
         def version = stdout.toString().trim()
         return !version.isEmpty() ? version - 'v' : projectVersion
     }
-    def useLastTag = project.hasProperty("useLastTag") ? project.getProperty("useLastTag").toBoolean() : false
 
     group = "io.sixhours"
-    version = useLastTag ? gitVersion() : projectVersion
+    version = useLastTag.toBoolean() ? gitVersion() : projectVersion
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
     id 'org.springframework.boot' version '2.2.1.RELEASE' apply false
     id 'com.jfrog.bintray' version '1.8.4'
+    id 'com.jfrog.artifactory' version '4.11.0'
     id 'org.sonarqube' version '2.8'
     id 'maven-publish'
     id 'java'

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,4 +1,24 @@
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.jfrog.artifactory'
+
+artifactory {
+    contextUrl = 'http://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = System.getenv('BINTRAY_USER')
+            password = System.getenv('BINTRAY_KEY')
+        }
+        defaults {
+            publications('mavenJava')
+            publishArtifacts = true
+            publishPom = true
+        }
+    }
+    resolve {
+        repoKey = 'jcenter'
+    }
+}
 
 bintray {
     user = System.getenv('BINTRAY_USER')

--- a/travisBuild.sh
+++ b/travisBuild.sh
@@ -6,6 +6,8 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew build
+#  Remove comment to enable automatic snapshot publishing
+#  ./gradlew build artifactoryPublish
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in

--- a/travisBuild.sh
+++ b/travisBuild.sh
@@ -3,6 +3,9 @@
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
   ./gradlew build
+elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$BUILD_PUBLISH" == "false" ]; then
+  echo -e "Build Branch => Branch [$TRAVIS_BRANCH]"
+  ./gradlew build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
   ./gradlew build artifactoryPublish

--- a/travisBuild.sh
+++ b/travisBuild.sh
@@ -5,9 +5,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   ./gradlew build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew build
-#  Remove comment to enable automatic snapshot publishing
-#  ./gradlew build artifactoryPublish
+  ./gradlew build artifactoryPublish
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in

--- a/travisBuild.sh
+++ b/travisBuild.sh
@@ -12,7 +12,7 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
   v[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*)
-    ./gradlew build bintrayUpload
+    ./gradlew build bintrayUpload -PuseLastTag=true
     ;;
   *)
     echo -e 'WARN: Invalid Tag ['$TRAVIS_TAG']'


### PR DESCRIPTION
Adds support for publishing a snapshot versions to [oss.jfrog.org](https://oss.jfrog.org). 
Build will be performed against OpenJDK 8, 11 & 13. Only the version built with OpenJDK 8 will be published: either as snapshot or as release version.

Snapshot versions will be available at the following repository:
https://oss.jfrog.org/artifactory/oss-snapshot-local