### PR TITLE
Perform Sonar analysis for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ services:
 jobs:
   include:
     - jdk: openjdk8
-      env: BUILD_PUBLISH=true
+      env:
+        - BUILD_PUBLISH=true
+        - SONAR_ANALYSIS=false
     - jdk: openjdk11
-      env: BUILD_PUBLISH=false
+      env:
+        - BUILD_PUBLISH=false
+        - SONAR_ANALYSIS=true
     - jdk: openjdk13
-      env: BUILD_PUBLISH=false
+      env:
+        - BUILD_PUBLISH=false
+        - SONAR_ANALYSIS=false
 script: ./travisBuild.sh
 after_success:
   - ./sonarcloud.sh

--- a/sonarcloud.sh
+++ b/sonarcloud.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$SONAR_ANALYSIS" == "true" ]; then
+  echo -e 'Sonar analysis => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   ./gradlew sonarqube -Dsonar.host.url=$SONAR_HOST -Dsonar.organization=$SONAR_ORG -Dsonar.login=$SONAR_TOKEN -Dsonar.verbose=true
 fi


### PR DESCRIPTION
Due to [depreciation](https://sonarcloud.io/documentation/user-guide/move-analysis-java-11/) of Java 8 SonarCloud analysis, perform analysis with Java 11 job.