### PR TITLE
adding disable-cache-names feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ memcached.cache.protocol: # Memcached client protocol. Supports "text" and "bina
 memcached.cache.operation-timeout: # Memcached client operation timeout (default "2500 milliseconds"). If unit not specified, milliseconds will be used.
 memcached.cache.hash-strategy: # Memcached client hash strategy for distribution of data between servers. Supports "standard" (array based : "hash(key) mod server_count"), "libmemcached" (consistent hash), "ketama" (consistent hash), "php" (make easier to share data with PHP based clients), "election", "roundrobin", "random". Default is "standard".
 memcached.cache.servers-refresh-interval: # Interval in milliseconds that refreshes the list of cache node hostnames and IP addresses for AWS ElastiCache. The default is 60000 milliseconds.
+memcached.cache.disabled-cache-names: # cache names to be disabled, dynamic or static. Useful for debugging if a cache name is causing an issue 
 ```
 
 All of the values have sensible defaults and are bound to [MemcachedCacheProperties](https://github.com/sixhours-team/memcached-spring-boot/blob/master/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java) class.

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheManagerFactory.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheManagerFactory.java
@@ -40,6 +40,7 @@ public abstract class MemcachedCacheManagerFactory {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (int) e.getValue().getSeconds())));
         cacheManager.setPrefix(properties.getPrefix());
         cacheManager.setNamespace(Default.NAMESPACE);
+        cacheManager.setDisabledCacheNames(properties.getDisableCacheNames());
 
         return cacheManager;
     }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
@@ -24,8 +24,10 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -43,6 +45,11 @@ public class MemcachedCacheProperties {
      * Comma-separated list of hostname:port for memcached servers. The default hostname:port is 'localhost:11211'.
      */
     private List<InetSocketAddress> servers = Default.SERVERS;
+
+    /**
+     * Comma-separated list of cache names to disable
+     */
+    private Set<String> disableCacheNames = new HashSet<>();
 
     /**
      * Memcached server provider. Use 'appengine' if running on Google Cloud Platform;
@@ -188,6 +195,14 @@ public class MemcachedCacheProperties {
 
     public void setHashStrategy(HashStrategy hashStrategy) {
         this.hashStrategy = hashStrategy;
+    }
+
+    public Set<String> getDisableCacheNames() {
+        return disableCacheNames;
+    }
+
+    public void setDisableCacheNames(Set<String> disableCacheNames) {
+        this.disableCacheNames = disableCacheNames;
     }
 
     public enum Protocol {

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheManagerTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCacheManagerTest.java
@@ -18,8 +18,11 @@ package io.sixhours.memcached.cache;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cache.Cache;
+import org.springframework.cache.support.NoOpCache;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -71,5 +74,15 @@ public class MemcachedCacheManagerTest {
 
         assertThat(cacheNamesArray).hasSize(1);
         assertThat(cacheNamesArray[0]).isEqualTo(EXISTING_CACHE);
+    }
+
+    @Test
+    public void whenGetDisabledCacheThenIncreaseCacheSize() {
+        final Set<String> disabledCacheNames = new HashSet<>();
+        disabledCacheNames.add(EXISTING_CACHE);
+        cacheManager.setDisabledCacheNames(disabledCacheNames);
+        Cache cache = cacheManager.getCache(EXISTING_CACHE);
+
+        assertThat(cache).isInstanceOf(NoOpCache.class);
     }
 }

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesDefaultValuesTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesDefaultValuesTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -84,6 +85,14 @@ public class MemcachedCachePropertiesDefaultValuesTest {
 
         assertThat(result).isNotNull();
         assertThat(result).isEqualTo(Duration.ofMillis(2500));
+    }
+
+    @Test
+    public void whenGetDisabledCaches_thenCorrectValue() {
+        Set<String> result = memcachedCacheProperties.getDisableCacheNames();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesTest.java
@@ -28,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -107,12 +108,22 @@ public class MemcachedCachePropertiesTest {
     }
 
     @Test
+    public void whenGetDisabledCaches_thenCorrectValue() {
+        Set<String> result = memcachedCacheProperties.getDisableCacheNames();
+
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+        assertThat(result).contains("disabled_cache_name");
+        assertThat(result).contains("something");
+    }
+
+    @Test
     public void whenGetExpirationPerCache_thenCorrectValue() {
         Map<String, Duration> result = memcachedCacheProperties.getExpirationPerCache();
 
         assertThat(result).isNotNull();
         assertThat(result.isEmpty()).isFalse();
-        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.size()).isEqualTo(4);
         // @formatter:off
         assertThat(result).contains(
                 entry("cache_name1", Duration.ofSeconds(3600)),

--- a/memcached-spring-boot-autoconfigure/src/test/resources/application-config-test.yml
+++ b/memcached-spring-boot-autoconfigure/src/test/resources/application-config-test.yml
@@ -26,4 +26,6 @@ memcached.cache:
     cache_name1: 3600
     cache_name2: 108000
     cache_name3: 7200
+    disabled_cache_name: 7200
   hash-strategy: ketama
+  disable-cache-names: "disabled_cache_name,something"


### PR DESCRIPTION
This can be useful when you feel that something is wrong with a particular dynamic cache-name and you want to see how your code behaves without it, without having to re-deploy your service.

Feel free to edit or refactor the code if necessary. If it's too farfetched, it's not complicated to have this functionality with a wrapper (that's how I have it today)