### PR TITLE
Remove the private constructor of auto-configuration classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To plug-in Memcached cache in your application follow the steps below:
    * **Gradle**
 
       ```groovy
-      implementation('io.sixhours:memcached-spring-boot-starter:2.4.0')
+      implementation('io.sixhours:memcached-spring-boot-starter:2.4.1')
       ```
    * **Maven**
 
@@ -27,7 +27,7 @@ To plug-in Memcached cache in your application follow the steps below:
       <dependency>
           <groupId>io.sixhours</groupId>
           <artifactId>memcached-spring-boot-starter</artifactId>
-          <version>2.4.0</version>
+          <version>2.4.1</version>
       </dependency>
       ```
   
@@ -36,7 +36,7 @@ To plug-in Memcached cache in your application follow the steps below:
    * **Gradle**
 
         ```groovy
-        implementation('io.sixhours:memcached-spring-boot-starter:2.4.0') {
+        implementation('io.sixhours:memcached-spring-boot-starter:2.4.1') {
           exclude group: 'com.googlecode.xmemcached', module: 'xmemcached'
         }
         implementation('com.amazonaws:elasticache-java-cluster-client:1.1.2')
@@ -47,7 +47,7 @@ To plug-in Memcached cache in your application follow the steps below:
         <dependency>
             <groupId>io.sixhours</groupId>
             <artifactId>memcached-spring-boot-starter</artifactId>
-            <version>2.4.0</version>
+            <version>2.4.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.googlecode.xmemcached</groupId>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/sixhours-team/memcached-spring-boot.svg?branch=master)](https://travis-ci.org/sixhours-team/memcached-spring-boot)
+[![Build Status](https://app.travis-ci.com/sixhours-team/memcached-spring-boot.svg?branch=master)](https://travis-ci.org/sixhours-team/memcached-spring-boot)
 [![codecov](https://codecov.io/gh/sixhours-team/memcached-spring-boot/branch/master/graph/badge.svg)](https://codecov.io/gh/sixhours-team/memcached-spring-boot)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=io.sixhours%3Amemcached-spring-boot&metric=alert_status)](https://sonarcloud.io/dashboard?id=io.sixhours%3Amemcached-spring-boot)
 [![Join the chat at gitter.im/six-hours/memcached-spring-boot](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/six-hours/memcached-spring-boot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     elasticacheClientVersion = '1.1.2'
     appengineApiVersion = '1.9.80'
     commonsLoggingVersion = '1.2'
-    testcontainersVersion = '1.15.0-rc2'
+    testcontainersVersion = '1.16.0'
 }
 
 ext.JAVA_GRADLE = "$rootDir/gradle/java.gradle"
@@ -25,7 +25,7 @@ ext.RELEASE_GRADLE = "$rootDir/gradle/release.gradle"
 ext.SONAR_GRADLE = "$rootDir/gradle/sonar.gradle"
 
 ext {
-    projectVersion = '2.4.0-SNAPSHOT'
+    projectVersion = '2.4.2-SNAPSHOT'
     useLastTag = false
 }
 

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/AppEngineMemcachedCacheAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/AppEngineMemcachedCacheAutoConfiguration.java
@@ -44,10 +44,6 @@ import java.io.IOException;
 @AutoConfigureAfter(name = "org.springframework.cloud.autoconfigure.RefreshAutoConfiguration")
 public class AppEngineMemcachedCacheAutoConfiguration {
 
-    private AppEngineMemcachedCacheAutoConfiguration() {
-        // Hide public constructor
-    }
-
     @Configuration
     @ConditionalOnRefreshScope
     static class RefreshableMemcachedCacheConfiguration {

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheAutoConfiguration.java
@@ -42,10 +42,6 @@ import java.io.IOException;
 @EnableConfigurationProperties(MemcachedCacheProperties.class)
 public class SpyMemcachedCacheAutoConfiguration {
 
-    private SpyMemcachedCacheAutoConfiguration() {
-        // Hide public constructor
-    }
-
     @Configuration
     @ConditionalOnRefreshScope
     static class RefreshableMemcachedCacheConfiguration {

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedCacheAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedCacheAutoConfiguration.java
@@ -43,10 +43,6 @@ import java.io.IOException;
 @EnableConfigurationProperties(MemcachedCacheProperties.class)
 public class XMemcachedCacheAutoConfiguration {
 
-    private XMemcachedCacheAutoConfiguration() {
-        // Hide public constructor
-    }
-
     @Configuration
     @ConditionalOnRefreshScope
     static class RefreshableMemcachedCacheConfiguration {


### PR DESCRIPTION
Hiding the public constructor from auto-configuration classes casuses
the issue on application startup for Spring Boot version <= 2.1.x.

Removing the private constructor and letting the compiler to provide
default no-arg constructor resolves the issue.

Resolves #128