### PR TITLE
Publish new library versions to the Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Library that provides support for auto-configuration of Memcached cache in a Spring Boot application.
 
 It provides implementation for the [Spring Cache Abstraction](https://docs.spring.io/spring/docs/5.2.3.RELEASE/spring-framework-reference/integration.html#cache), backed by the [Xmemcached](https://github.com/killme2008/xmemcached).
-Supports cache eviction per key, as well as clearing out of the entire cache region. Binaries are available from **Maven Central** and **JCenter**.
+Supports cache eviction per key, as well as clearing out of the entire cache region. Binaries are available from **Maven Central**.
 
 ## Usage
 
@@ -64,7 +64,7 @@ To plug-in Memcached cache in your application follow the steps below:
 
   * Snapshot repository
 
-    If you want to use `SNAPSHOT` versions, add the snapshot-repo `https://oss.jfrog.org/artifactory/libs-snapshot/` as shown in the [example](https://github.com/sixhours-team/spring-boot-memcached-demo-java/blob/master/build.gradle#L16).
+    If you want to use `SNAPSHOT` versions, add the snapshot-repo `https://oss.sonatype.org/content/repositories/snapshots` as shown in the [example](https://github.com/sixhours-team/spring-boot-memcached-demo-java/blob/master/build.gradle#L16).
 
 2. Configure `Memcached` key-value store in your properties file (`application.yml`).
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     id 'org.springframework.boot' version '2.3.0.RELEASE' apply false
-    id 'com.jfrog.bintray' version '1.8.5'
-    id 'com.jfrog.artifactory' version '4.15.2'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     id 'com.github.hierynomus.license' version '0.15.0'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'org.sonarqube' version '3.0'
@@ -29,6 +28,8 @@ ext {
     useLastTag = false
 }
 
+apply from: RELEASE_GRADLE
+
 allprojects {
     def gitVersion = { ->
         def stdout = new ByteArrayOutputStream()
@@ -49,7 +50,6 @@ subprojects {
     apply from: JAVA_GRADLE
     apply from: LICENSE_GRADLE
     apply from: PUBLISH_GRADLE
-    apply from: RELEASE_GRADLE
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'java-library'
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,40 +1,8 @@
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'com.jfrog.artifactory'
-
-artifactory {
-    contextUrl = 'https://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = System.getenv('BINTRAY_USER')
-            password = System.getenv('BINTRAY_KEY')
-        }
-        defaults {
-            publications('mavenJava')
-            publishArtifacts = true
-            publishPom = true
-        }
-    }
-    resolve {
-        repoKey = 'jcenter'
-    }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    publications = ['mavenJava']
-    pkg {
-        repo = 'maven'
-        userOrg = 'sixhours-team'
-        name = "${project.group}:${project.name}"
-        websiteUrl = 'https://github.com/sixhours-team/memcached-spring-boot'
-        issueTrackerUrl = 'https://github.com/sixhours-team/memcached-spring-boot/issues'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/sixhours-team/memcached-spring-boot'
-        version {
-            name = project.version
-            released = new Date()
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv('SONATYPE_USER')
+            password = System.getenv('SONATYPE_PASSWORD')
         }
     }
 }

--- a/travisBuild.sh
+++ b/travisBuild.sh
@@ -8,12 +8,12 @@ elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$BUILD_PUBLISH" == "false" ]; t
   ./gradlew build
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
   echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
-  ./gradlew build artifactoryPublish
+  ./gradlew build publishToSonatype
 elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
   echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
   case "$TRAVIS_TAG" in
   v[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*)
-    ./gradlew build bintrayUpload -x :bintrayUpload -PuseLastTag=true
+    ./gradlew build publishToSonatype closeSonatypeStagingRepository -PuseLastTag=true
     ;;
   *)
     echo -e 'WARN: Invalid Tag ['$TRAVIS_TAG']'


### PR DESCRIPTION
Being the Bintray services are no longer available, the existing pipeline
is updated to publish artifacts to Maven Central via Sonatype's Nexus repository.

Resovles #130