### PR TITLE
Allow customization of SpyMemcached client

### DIFF
--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Sixhours
+ * Copyright 2016-2022 Sixhours
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ public class SpyMemcachedCacheAutoConfiguration {
         @Bean
         @RefreshScope
         @ConditionalOnMissingBean(value = MemcachedCacheManager.class, search = SearchStrategy.CURRENT)
-        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties) throws IOException {
-            return new SpyMemcachedCacheManagerFactory(properties).create();
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, SpyMemcachedConnectionFactoryCustomizer customizer) throws IOException {
+            return new SpyMemcachedCacheManagerFactory(properties, customizer).create();
         }
     }
 
@@ -60,8 +60,14 @@ public class SpyMemcachedCacheAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean(value = MemcachedCacheManager.class, search = SearchStrategy.CURRENT)
-        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties) throws IOException {
-            return new SpyMemcachedCacheManagerFactory(properties).create();
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, SpyMemcachedConnectionFactoryCustomizer customizer) throws IOException {
+            return new SpyMemcachedCacheManagerFactory(properties, customizer).create();
         }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(value = SpyMemcachedConnectionFactoryCustomizer.class)
+    public SpyMemcachedConnectionFactoryCustomizer spyMemcachedConnectionFactoryCustomizer() {
+        return (builder) -> {};
     }
 }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheManagerFactory.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 Sixhours
+ * Copyright 2016-2022 Sixhours
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,11 @@ import java.util.List;
  */
 public class SpyMemcachedCacheManagerFactory extends MemcachedCacheManagerFactory {
 
-    public SpyMemcachedCacheManagerFactory(MemcachedCacheProperties properties) {
+    private final SpyMemcachedConnectionFactoryCustomizer connectionFactoryCustomizer;
+
+    public SpyMemcachedCacheManagerFactory(MemcachedCacheProperties properties, SpyMemcachedConnectionFactoryCustomizer customizer) {
         super(properties);
+        this.connectionFactoryCustomizer = customizer;
     }
 
     @Override
@@ -47,9 +50,10 @@ public class SpyMemcachedCacheManagerFactory extends MemcachedCacheManagerFactor
                 .setOpTimeout(properties.getOperationTimeout().toMillis())
                 .setProtocol(connectionProtocol(protocol));
 
+        connectionFactoryCustomizer.customize(connectionFactoryBuilder);
+
         return new SpyMemcachedClient(new MemcachedClient(connectionFactoryBuilder.build(), servers));
     }
-
 
     private ClientMode clientMode(MemcachedCacheProperties.Provider provider) {
         switch (provider) {

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedConnectionFactoryCustomizer.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedConnectionFactoryCustomizer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016-2022 Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sixhours.memcached.cache;
+
+import net.spy.memcached.ConnectionFactoryBuilder;
+
+public interface SpyMemcachedConnectionFactoryCustomizer {
+    void customize(ConnectionFactoryBuilder builder);
+}


### PR DESCRIPTION
Hi, we have a case of configuration of the Spy memcached client that is not covered by the common set of properties in the library (in our case enable the keepAlive flag), as there are other options that are not shared with the other implementations the idea is to allow to provide an implementation of a customizer that gives you access to the Builder object, so you can customize it.