### PR TITLE
Add support for Spring Boot 3 auto-configuration

### DIFF
--- a/memcached-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/memcached-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.sixhours.memcached.cache.MemcachedCacheAutoConfiguration
+io.sixhours.memcached.cache.MemcachedCacheMeterBinderProviderConfiguration


### PR DESCRIPTION
Since **Spring Boot 2.7** the auto-configuration file has been moved to a new file named 
`META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

Adding existing configuration from `spring.factories` file should allow auto-configuration
registration for **Spring Boot 3**.

For backwards compatibility, entries will be kept in `spring.factories` as well.