### PR TITLE
Add support for using expirations of more than 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To plug-in Memcached cache in your application follow the steps below:
      memcached.cache:
        servers: example1.com:11211,example2.com:11211
        provider: static
-       # default expiration is '1d' ('86400' seconds) and custom ones for cache_name1 and cache_name2
+       # default expiration set to '1d' (1 day i.e. '86400' seconds) and custom ones for cache_name1 and cache_name2
        expiration: 1d
        expiration-per-cache:
          cache_name1: 1h
@@ -148,8 +148,8 @@ full list of supported properties:
 # MEMCACHED CACHE
 memcached.cache.servers: # Comma-separated list of hostname:port for memcached servers (default "localhost:11211")
 memcached.cache.provider: # Memcached server provider (use one of following: "static", "aws" or "appengine"). Default provider is "static". Use "aws" for AWS node auto discovery, or "appengine" if running on Google Cloud Platform.
-memcached.cache.expiration: # Default cache expiration if not configured per cache (default "0", meaning that cache will never expire). If unit not specified, seconds will be used.
-memcached.cache.expiration-per-cache.cacheName: # To set expiration value for cache named "cacheName" {cache_name}:{number} e.g. "authors: 3600" or "authors: 1h". If unit not specified, seconds will be used.
+memcached.cache.expiration: # Default cache expiration (defaults to "0", meaning that cache will never expire). If duration unit is not specified, seconds will be used by default.
+memcached.cache.expiration-per-cache.cacheName: # Set expiration for cache with given name. Overrides `memcached.cache.expiration` for the given cache. To set expiration value for cache named "cacheName" {cache_name}:{number} e.g. "authors: 3600" or "authors: 1h". If duration unit is not specified, seconds will be used by default.
 memcached.cache.prefix: # Cache key prefix (default "memcached:spring-boot")
 memcached.cache.protocol: # Memcached client protocol. Supports "text" and "binary" protocols (default is "text" protocol)
 memcached.cache.operation-timeout: # Memcached client operation timeout (default "2500 milliseconds"). If unit not specified, milliseconds will be used.

--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,13 @@ plugins {
 }
 
 ext {
-    springCloudVersion = 'Hoxton.SR4'
-    xmemcachedVersion = '2.4.6'
-    elasticacheClientVersion = '1.1.2'
     appengineApiVersion = '1.9.80'
+    awaitilityVersion = '4.2.0'
     commonsLoggingVersion = '1.2'
-    testcontainersVersion = '1.16.0'
+    elasticacheClientVersion = '1.1.2'
+    springCloudVersion = 'Hoxton.SR4'
+    testcontainersVersion = '1.17.6'
+    xmemcachedVersion = '2.4.6'
 }
 
 ext.JAVA_GRADLE = "$rootDir/gradle/java.gradle"
@@ -34,7 +35,7 @@ def gitVersion = { ->
     return !version.isEmpty() ? version - 'v' : projectVersion
 }
 
-def resolvedVersion = project.findProperty('release') ? gitVersion() : '2.4.5-SNAPSHOT'
+def resolvedVersion = project.findProperty('release') ? gitVersion() : '2.5.0-SNAPSHOT'
 
 sonarqube {
     properties {

--- a/memcached-spring-boot-autoconfigure/build.gradle
+++ b/memcached-spring-boot-autoconfigure/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'javax.cache:cache-api'
+    testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
     integrationTestImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
 }
 

--- a/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/MemcachedCacheContextConfigIT.java
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/MemcachedCacheContextConfigIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016-2023 Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sixhours.memcached.cache;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = MemcachedCacheContextConfigIT.DefaultConfig.class, initializers = ConfigFileApplicationContextInitializer.class)
+public class MemcachedCacheContextConfigIT {
+
+    @Autowired
+    private MemcachedCacheManager memcachedCacheManager;
+
+    @Autowired
+    private MemcachedCacheProperties properties;
+
+    @Test
+    public void contextLoads() {
+        // Cache manager with default XMemcached client loaded
+        assertThat(memcachedCacheManager).isNotNull();
+        assertThat(memcachedCacheManager.client()).isNotNull();
+        assertThat(memcachedCacheManager.client()).isInstanceOf(XMemcachedClient.class);
+
+        // Configuration properties loaded
+        assertThat(properties).isNotNull();
+        assertThat(properties.getServers()).hasSize(2);
+        assertThat(properties.getServers().get(0)).isNotNull();
+        assertThat(properties.getServers().get(0).getHostName()).isEqualTo("example1.com");
+        assertThat(properties.getServers().get(0).getPort()).isEqualTo(12345);
+        assertThat(properties.getServers().get(1)).isNotNull();
+        assertThat(properties.getServers().get(1).getHostName()).isEqualTo("example2.com");
+        assertThat(properties.getServers().get(1).getPort()).isEqualTo(12346);
+        assertThat(properties.getServersRefreshInterval()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(properties.getOperationTimeout()).isEqualTo(Duration.ofMillis(7200));
+        assertThat(properties.getPrefix()).isEqualTo("memcached:test-app");
+        assertThat(properties.getProtocol()).isEqualTo(MemcachedCacheProperties.Protocol.TEXT);
+        assertThat(properties.getProvider()).isEqualTo(MemcachedCacheProperties.Provider.STATIC);
+        assertThat(properties.getExpiration()).isEqualTo(Duration.ofDays(40));
+        assertThat(properties.getExpirationPerCache()).hasSize(4);
+        assertThat(properties.getExpirationPerCache().get("cache_name1")).isEqualTo(Duration.ofHours(1));
+        assertThat(properties.getExpirationPerCache().get("cache_name2")).isEqualTo(Duration.ofHours(10));
+        assertThat(properties.getExpirationPerCache().get("cache_name3")).isEqualTo(Duration.ofHours(2));
+        assertThat(properties.getExpirationPerCache().get("cache_name4")).isEqualTo(Duration.ofDays(60));
+        assertThat(properties.getHashStrategy()).isEqualTo(MemcachedCacheProperties.HashStrategy.KETAMA);
+        assertThat(properties.getMetricsCacheNames())
+                .hasSize(3)
+                .containsExactly(
+                        "cache_name1",
+                        "cache_name2",
+                        "cache_name3"
+                );
+        assertThat(properties.getDisabledCacheNames())
+                .hasSize(3)
+                .containsExactlyInAnyOrder(
+                        "disabled_cache_name",
+                        "something",
+                        "nothing"
+                );
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @EnableCaching
+    static class DefaultConfig {
+
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/MemcachedCacheExpirationIT.java
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/MemcachedCacheExpirationIT.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2016-2023 Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sixhours.memcached.cache;
+
+import net.rubyeye.xmemcached.XMemcachedClientBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Memcached cache expiration integration tests.
+ *
+ * @author Igor Bolic
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = MemcachedCacheExpirationIT.CacheConfig.class)
+public class MemcachedCacheExpirationIT {
+
+    @ClassRule
+    public static GenericContainer memcached = new GenericContainer("memcached:alpine")
+            .withExposedPorts(11211);
+
+    @Autowired
+    MemcachedCacheManager cacheManager;
+
+    @Autowired
+    IMemcachedClient memcachedClient;
+
+    @Before
+    public void setUp() {
+        // Clear cache before each test
+        memcachedClient.flush();
+    }
+
+    @Test
+    public void whenNewCacheCacheExpiresThenCachedValueNotFound() {
+        // Given new cache and default expiration of 4 seconds
+        Cache cache = cacheManager.getCache("cache");
+        assertThat(cache).isNotNull();
+        assertThat(cache).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        cache.put("key", "value");
+
+        // Then cached value expires in 5 seconds
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = cache.get("key");
+
+            assertThat(actual).isNull();
+        });
+    }
+
+    @Test
+    public void whenAuthorsCacheExpiresThenCachedValueNotFound() {
+        // Given authors cache with expiration in 3 seconds
+        Cache authors = cacheManager.getCache("authors");
+        assertThat(authors).isNotNull();
+        assertThat(authors).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        authors.put("test-key", "value");
+
+        // Then cached value expires in 4 seconds
+        await().atMost(Duration.ofSeconds(4)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = authors.get("test-key");
+
+            assertThat(actual).isNull();
+        });
+    }
+
+    @Test
+    public void whenExpirationInThirtyDaysThenValueCached() {
+        // Given Instant.now() time is 30 days and 2 seconds in the past
+        Instant pastTime = Instant.now()
+                .minusSeconds(Duration.ofDays(30).minusSeconds(2).getSeconds());
+        Clock clock = Clock.fixed(pastTime, ZoneId.of("UTC"));
+
+        // Use the test clock time
+        cacheManager.setClock(clock);
+
+        Instant now = Instant.now(clock);
+        assertThat(now).isEqualTo(pastTime);
+
+        // Given 30-day cache with expiration in 30 days
+        Cache cache = cacheManager.getCache("30-days");
+        assertThat(cache).isNotNull();
+        assertThat(cache).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        cache.put("test-key", "value");
+
+        // Then value should be found in cache i.e. unix timestamp
+        // should not have been used for setting the expiration time,
+        // since if it was, the expiration time would be in past
+        Cache.ValueWrapper actual = cache.get("test-key");
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.get()).isEqualTo("value");
+    }
+
+    @Test
+    public void whenExpirationInThirtyDaysAndSecondThenValueCached() {
+        // Given Instant.now() time is 30 days and 2 second in the past
+        Instant pastTime = Instant.now()
+                .minusSeconds(Duration.ofDays(30).minusSeconds(2).getSeconds());
+        Clock clock = Clock.fixed(pastTime, ZoneId.of("UTC"));
+
+        // Use the test clock time
+        cacheManager.setClock(clock);
+
+        Instant now = Instant.now(clock);
+        assertThat(now).isEqualTo(pastTime);
+
+        // Given 30-day cache with expiration in 30 days and 1 second
+        Cache cache = cacheManager.getCache("30-days-1-second");
+        assertThat(cache).isNotNull();
+        assertThat(cache).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        cache.put("test-key", "value");
+
+        // The unix timestamp should have been added with the expiration in seconds
+        // i.e. in case it was not, the expiration would equal to
+        // Instant.ofEpochSecond(60*60*24*30 + 1) = 1970-01-31T00:00:01Z, which is in the
+        // past, and therefore value would not have been cached at all.
+
+        // Then value should be available in cache for the first 2 seconds
+        await().during(Duration.ofSeconds(2)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = cache.get("test-key");
+
+            assertThat(actual).isNotNull();
+            assertThat(actual.get()).isEqualTo("value");
+        });
+        // And should not be found in cache within next 2 seconds
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = cache.get("test-key");
+
+            assertThat(actual).isNull();
+        });
+    }
+
+    @Test
+    public void whenExpirationInThirtyDaysAndSomeSecondsThenUnixTimestampExpirationUsed() {
+        // Given Instant.now() time is 30 days and 2 seconds in the past
+        Instant pastTime = Instant.now()
+                .minusSeconds(Duration.ofDays(30).minusSeconds(2).getSeconds());
+        Clock clock = Clock.fixed(pastTime, ZoneId.of("UTC"));
+
+        // Use the test clock time
+        cacheManager.setClock(clock);
+
+        Instant now = Instant.now(clock);
+        assertThat(now).isEqualTo(pastTime);
+
+        // Given expiration in 30 days and 4 seconds
+        Cache fourSeconds = cacheManager.getCache("30-days-4-seconds");
+        assertThat(fourSeconds).isNotNull();
+        assertThat(fourSeconds).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        fourSeconds.put("test-4-key-expired", "value-not-expired");
+
+        // Cache should expire in 6 seconds i.e. current time is past time (2 seconds) + 4 seconds.
+        // Being Memcached expiration precision / unit is 1 second, the key should for sure expire
+        // in the next 7 seconds, if not before.
+
+        // Then cache should not expire in first 4 seconds
+        await().during(Duration.ofSeconds(4)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = fourSeconds.get("test-4-key-expired");
+
+            assertThat(actual).isNotNull();//
+            assertThat(actual.get()).isEqualTo("value-not-expired");
+        });
+        // And should expire after additional 4 seconds
+        await().atMost(Duration.ofSeconds(4)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = fourSeconds.get("test-4-key-expired");
+
+            assertThat(actual).isNull();
+        });
+    }
+
+    @Test
+    public void whenExpirationInMoreThanThirtyDaysThenValueCached() {
+        // Given 40-days cache with expiration in 41 days
+        Cache cache = cacheManager.getCache("41-days");
+        assertThat(cache).isNotNull();
+        assertThat(cache).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        cache.put("test-key", "value");
+
+        // Then value is still found in cache after 2 seconds
+        await().during(Duration.ofSeconds(2)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = cache.get("test-key");
+
+            assertThat(actual).isNotNull();
+            assertThat(actual.get()).isEqualTo("value");
+        });
+    }
+
+    @Test
+    public void whenExpirationOfMoreThanThirtyDaysExpiresThenCachedValueNotFound() {
+        // Given Instant.now() time is 40 days and 2 seconds in the past
+        Instant pastTime = Instant.now()
+                .minusSeconds(Duration.ofDays(40).minusSeconds(2).getSeconds());
+        Clock clock = Clock.fixed(pastTime, ZoneId.of("UTC"));
+
+        // Use the test clock time
+        cacheManager.setClock(clock);
+
+        Instant now = Instant.now(clock);
+        assertThat(now).isEqualTo(pastTime);
+
+        // Given 40-days cache with expiration in 40 days i.e. in 2 seconds from Instant.now()
+        Cache forthyCache = cacheManager.getCache("40-days");
+        assertThat(forthyCache).isNotNull();
+        assertThat(forthyCache).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        forthyCache.put("test-key-expired", "value-expired");
+
+        // Then cache should expire in at most 3 seconds
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = forthyCache.get("test-key-expired");
+
+            assertThat(actual).isNull();
+        });
+
+        // Given expiration in 40 days and 4 seconds
+        Cache forthyAndFourCache = cacheManager.getCache("40-days-4-seconds");
+        assertThat(forthyAndFourCache).isNotNull();
+        assertThat(forthyAndFourCache).isInstanceOf(MemcachedCache.class);
+
+        // When value is cached
+        forthyAndFourCache.put("test-key-not-expired", "value-not-expired");
+
+        // Then cache should not expire in 3 seconds
+        await().during(Duration.ofSeconds(3)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = forthyAndFourCache.get("test-key-not-expired");
+
+            assertThat(actual).isNotNull();
+            assertThat(actual.get()).isEqualTo("value-not-expired");
+        });
+        // And should expire after additional 3 seconds
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
+            Cache.ValueWrapper actual = forthyAndFourCache.get("test-key-not-expired");
+
+            assertThat(actual).isNotNull();
+            assertThat(actual.get()).isEqualTo("value-not-expired");
+        });
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @EnableCaching
+    @ComponentScan(basePackageClasses = {AuthorService.class, BookService.class})
+    static class CacheConfig {
+
+        @Bean
+        public MemcachedCacheManager cacheManager() throws IOException {
+            final MemcachedCacheManager memcachedCacheManager = new MemcachedCacheManager(memcachedClient());
+            memcachedCacheManager.setExpiration(4);
+
+            Map<String, Integer> expirationsPerCache = new HashMap<>();
+            expirationsPerCache.put("authors", 3);
+            expirationsPerCache.put("30-days", (int) Duration.ofDays(30).getSeconds());
+            expirationsPerCache.put("30-days-1-second", (int) Duration.ofDays(30).plusSeconds(1).getSeconds());
+            expirationsPerCache.put("30-days-4-seconds", (int) Duration.ofDays(30).plusSeconds(4).getSeconds());
+            expirationsPerCache.put("40-days", (int) Duration.ofDays(40).getSeconds());
+            expirationsPerCache.put("40-days-4-seconds", (int) Duration.ofDays(40).plusSeconds(4).getSeconds());
+            expirationsPerCache.put("41-days", (int) Duration.ofDays(41).getSeconds());
+            memcachedCacheManager.setExpirationPerCache(expirationsPerCache);
+
+            return memcachedCacheManager;
+        }
+
+        @Bean
+        public IMemcachedClient memcachedClient() throws IOException {
+            final String host = memcached.getHost();
+            final int port = memcached.getMappedPort(11211);
+
+            return new XMemcachedClient(new XMemcachedClientBuilder(Collections.singletonList(new InetSocketAddress(host, port))).build());
+        }
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/integration-test/resources/application.yml
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/resources/application.yml
@@ -1,0 +1,32 @@
+#
+# Copyright 2016-2023 Sixhours
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+memcached.cache:
+  servers: example1.com:12345,example2.com:12346
+  servers-refresh-interval: 30000
+  operation-timeout: 7200
+  prefix: memcached:test-app
+  protocol: text
+  provider: static
+  expiration: 40d
+  expiration-per-cache:
+    cache_name1: 3600
+    cache_name2: 10h
+    cache_name3: 7200
+    cache_name4: 60d
+  hash-strategy: ketama
+  metrics-cache-names: cache_name1, cache_name2, cache_name3
+  disabled-cache-names: disabled_cache_name, something, nothing

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/Default.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/Default.java
@@ -15,15 +15,15 @@
  */
 package io.sixhours.memcached.cache;
 
-import static io.sixhours.memcached.cache.MemcachedCacheProperties.Protocol;
+import io.sixhours.memcached.cache.MemcachedCacheProperties.HashStrategy;
+import io.sixhours.memcached.cache.MemcachedCacheProperties.Provider;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 
-import io.sixhours.memcached.cache.MemcachedCacheProperties.HashStrategy;
-import io.sixhours.memcached.cache.MemcachedCacheProperties.Provider;
+import static io.sixhours.memcached.cache.MemcachedCacheProperties.Protocol;
+import static java.util.Collections.singletonList;
 
 /**
  * Default cache configuration values.
@@ -32,8 +32,7 @@ import io.sixhours.memcached.cache.MemcachedCacheProperties.Provider;
  */
 public final class Default {
 
-    public static final List<InetSocketAddress> SERVERS = Collections.unmodifiableList(
-            Collections.singletonList(new InetSocketAddress("localhost", 11211)));
+    public static final List<InetSocketAddress> SERVERS = singletonList(new InetSocketAddress("localhost", 11211));
 
     public static final Provider PROVIDER = Provider.STATIC;
 

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
@@ -15,7 +15,10 @@
  */
 package io.sixhours.memcached.cache;
 
-import static io.sixhours.memcached.cache.Default.SERVERS_REFRESH_INTERVAL;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationStyle;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.util.StringUtils;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -28,11 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.convert.DurationStyle;
-import org.springframework.boot.convert.DurationUnit;
-import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for Memcached cache.
@@ -69,6 +67,12 @@ public class MemcachedCacheProperties {
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration expiration = Duration.ofSeconds(Default.EXPIRATION);
 
+    /**
+     * Expiration per cache. The map contains cache name as the key and expiration as the value.
+     * <p>
+     * The expiration value in the map will override global {@code expiration}, but only for the cache with the name
+     * specified as the map key.
+     */
     private Map<String, Duration> expirationPerCache = new HashMap<>();
 
     /**
@@ -91,7 +95,7 @@ public class MemcachedCacheProperties {
      * Amazon ElastiCache configuration polling interval in milliseconds that refreshes the list of cache node hostnames and IP
      * addresses.  The default is 60000 milliseconds
      */
-    private Duration serversRefreshInterval = SERVERS_REFRESH_INTERVAL;
+    private Duration serversRefreshInterval = Default.SERVERS_REFRESH_INTERVAL;
 
     /**
      * Memcached client hash strategy for distribution of data between servers. Supports 'standard' (array based :
@@ -111,7 +115,7 @@ public class MemcachedCacheProperties {
      * @param value Comma-separated list
      */
     public void setServers(String value) {
-        if (StringUtils.isEmpty(value)) {
+        if (value == null || StringUtils.isEmpty(value)) {
             throw new IllegalArgumentException("Server list is empty");
         }
         this.servers = Stream.of(value.split("\\s*,\\s*"))
@@ -188,7 +192,7 @@ public class MemcachedCacheProperties {
     }
 
     public void setOperationTimeout(Duration operationTimeout) {
-        if (Duration.ZERO.compareTo(operationTimeout) >= 0) {
+        if (operationTimeout == null || Duration.ZERO.compareTo(operationTimeout) >= 0) {
             throw new IllegalArgumentException("Operation timeout must be greater then zero");
         }
         this.operationTimeout = operationTimeout;
@@ -199,15 +203,15 @@ public class MemcachedCacheProperties {
     }
 
     public void setServersRefreshInterval(Duration serversRefreshInterval) {
-        if (Duration.ZERO.compareTo(serversRefreshInterval) >= 0) {
+        if (serversRefreshInterval == null || Duration.ZERO.compareTo(serversRefreshInterval) >= 0) {
             throw new IllegalArgumentException("Servers refresh interval must be greater then zero");
         }
         this.serversRefreshInterval = serversRefreshInterval;
     }
 
     private void validateExpiration(Duration expiration) {
-        if (expiration == null || expiration.toDays() > 30) {
-            throw new IllegalStateException("Invalid expiration. It should not be null or greater than 30 days.");
+        if (expiration == null || expiration.isNegative()) {
+            throw new IllegalArgumentException("Invalid expiration. Duration must be greater than or equal to 0 (zero) seconds.");
         }
     }
 

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesValidationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesValidationTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2016-2023 Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sixhours.memcached.cache;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MemcachedCachePropertiesValidationTest {
+
+    private MemcachedCacheProperties properties;
+
+    @Before
+    public void setUp() {
+        properties = new MemcachedCacheProperties();
+    }
+
+    @Test
+    public void whenSetServersThenValidationOk() {
+        properties.setServers("example1.com:1122");
+
+        assertThat(properties.getServers()).hasSize(1);
+        assertThat(properties.getServers().get(0)).isNotNull();
+        assertThat(properties.getServers().get(0).getHostName()).isNotNull();
+        assertThat(properties.getServers().get(0).getHostName()).isEqualTo("example1.com");
+        assertThat(properties.getServers().get(0).getPort()).isEqualTo(1122);
+    }
+
+    @Test
+    public void whenSetNullServersThenValidationFails() {
+        assertThatThrownBy(() -> properties.setServers(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Server list is empty");
+    }
+
+    @Test
+    public void whenSetEmptyServersThenValidationFails() {
+        assertThatThrownBy(() -> properties.setServers(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Server list is empty");
+    }
+
+    @Test
+    public void whenSetBlankServersThenValidationFails() {
+        assertThatThrownBy(() -> properties.setServers(" "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid server value. It cannot be empty");
+    }
+
+    @Test
+    public void whenSetDisabledCacheNamesThenValidationOk() {
+        Set<String> names = new HashSet<>();
+        names.add("cache-1");
+        properties.setDisabledCacheNames(names);
+
+        assertThat(properties.getDisabledCacheNames()).hasSize(1);
+        assertThat(properties.getDisabledCacheNames()).containsExactly("cache-1");
+    }
+
+    @Test
+    public void whenSetEmptyDisabledCacheNamesThenValidationOk() {
+        properties.setDisabledCacheNames(new HashSet<>());
+
+        assertThat(properties.getDisabledCacheNames()).isEmpty();
+    }
+
+    @Test
+    public void whenSetMetricsCacheNamesThenValidationOk() {
+        List<String> names = new ArrayList<>();
+        names.add("cache-1");
+        properties.setMetricsCacheNames(names);
+
+        assertThat(properties.getMetricsCacheNames()).hasSize(1);
+        assertThat(properties.getMetricsCacheNames()).containsExactly("cache-1");
+    }
+
+    @Test
+    public void whenSetEmptyMetricsCacheNamesThenValidationOk() {
+        properties.setMetricsCacheNames(new ArrayList<>());
+
+        assertThat(properties.getMetricsCacheNames()).isEmpty();
+    }
+
+    @Test
+    public void whenSetNullMetricsCacheNamesThenValidationOk() {
+        properties.setMetricsCacheNames(null);
+
+        assertThat(properties.getMetricsCacheNames()).isNull();
+    }
+
+    @Test
+    public void whenSetProviderThenValidationOk() {
+        properties.setProvider(MemcachedCacheProperties.Provider.STATIC);
+
+        assertThat(properties.getProvider()).isEqualTo(MemcachedCacheProperties.Provider.STATIC);
+    }
+
+    @Test
+    public void whenSetNullProviderThenValidationOk() {
+        properties.setProvider(null);
+
+        assertThat(properties.getProvider()).isNull();
+    }
+
+    @Test
+    public void whenSetZeroExpirationThenValidationOk() {
+        properties.setExpiration(Duration.ZERO);
+
+        assertThat(properties.getExpiration()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    public void whenSetPositiveExpirationThenValidationOk() {
+        properties.setExpiration(Duration.ofDays(40));
+
+        assertThat(properties.getExpiration()).isEqualTo(Duration.ofDays(40));
+    }
+
+    @Test
+    public void whenSetNullExpirationThenValidationFails() {
+        assertThatThrownBy(() -> properties.setExpiration(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid expiration. Duration must be greater than or equal to 0 (zero) seconds.");
+    }
+
+    @Test
+    public void whenSetNegativeExpirationThenValidationFails() {
+        assertThatThrownBy(() -> properties.setExpiration(Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid expiration. Duration must be greater than or equal to 0 (zero) seconds.");
+    }
+
+    @Test
+    public void whenSetExpirationPerCacheThenValidationOk() {
+        Map<String, String> perCache = new HashMap<>();
+        perCache.put("cache-1", "1d");
+        perCache.put("cache-2", "15h");
+        perCache.put("cache-3", "30d");
+        perCache.put("cache-4", "40d");
+
+        properties.setExpirationPerCache(perCache);
+
+        assertThat(properties.getExpirationPerCache()).hasSize(4);
+        assertThat(properties.getExpirationPerCache().get("cache-1")).isEqualTo(Duration.ofDays(1));
+        assertThat(properties.getExpirationPerCache().get("cache-2")).isEqualTo(Duration.ofHours(15));
+        assertThat(properties.getExpirationPerCache().get("cache-3")).isEqualTo(Duration.ofDays(30));
+        assertThat(properties.getExpirationPerCache().get("cache-4")).isEqualTo(Duration.ofDays(40));
+    }
+
+    @Test
+    public void whenSetNullExpirationPerCacheThenValidationOk() {
+        properties.setExpirationPerCache(null);
+
+        assertThat(properties.getExpirationPerCache()).isEmpty();
+    }
+
+    @Test
+    public void whenSetNegativeExpirationPerCacheThenValidationFails() {
+        Map<String, String> perCache = new HashMap<>();
+        perCache.put("cache-1", "-1d");
+        perCache.put("cache-4", "40d");
+
+        assertThatThrownBy(() -> properties.setExpirationPerCache(perCache))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid expiration. Duration must be greater than or equal to 0 (zero) seconds.");
+    }
+
+    @Test
+    public void whenSetPrefixThenValidationOk() {
+        properties.setPrefix("my-cache");
+
+        assertThat(properties.getPrefix()).isEqualTo("my-cache");
+    }
+
+    @Test
+    public void whenSetNullPrefixThenValidationOk() {
+        properties.setPrefix(null);
+
+        assertThat(properties.getPrefix()).isNull();
+    }
+
+    @Test
+    public void whenSetProtocolThenValidationOk() {
+        properties.setProtocol(MemcachedCacheProperties.Protocol.TEXT);
+
+        assertThat(properties.getProtocol()).isEqualTo(MemcachedCacheProperties.Protocol.TEXT);
+    }
+
+    @Test
+    public void whenSetNullProtocolThenValidationOk() {
+        properties.setProtocol(null);
+
+        assertThat(properties.getProtocol()).isNull();
+    }
+
+    @Test
+    public void whenSetOperationTimeoutThenValidationOk() {
+        properties.setOperationTimeout(Duration.ofHours(4));
+
+        assertThat(properties.getOperationTimeout()).isEqualTo(Duration.ofHours(4));
+    }
+
+    @Test
+    public void whenSetNullOperationTimeoutThenValidationFails() {
+        assertThatThrownBy(() -> properties.setOperationTimeout(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Operation timeout must be greater then zero");
+    }
+
+    @Test
+    public void whenSetZeroOperationTimeoutThenValidationFails() {
+        assertThatThrownBy(() -> properties.setOperationTimeout(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Operation timeout must be greater then zero");
+    }
+
+    @Test
+    public void whenSetNegativeOperationTimeoutThenValidationFails() {
+        assertThatThrownBy(() -> properties.setOperationTimeout(Duration.ofDays(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Operation timeout must be greater then zero");
+    }
+
+    @Test
+    public void whenSetServersRefreshIntervalThenValidationOk() {
+        properties.setServersRefreshInterval(Duration.ofHours(4));
+
+        assertThat(properties.getServersRefreshInterval()).isEqualTo(Duration.ofHours(4));
+    }
+
+    @Test
+    public void whenSetNullServersRefreshIntervalThenValidationFails() {
+        assertThatThrownBy(() -> properties.setServersRefreshInterval(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Servers refresh interval must be greater then zero");
+    }
+
+    @Test
+    public void whenSetZeroServersRefreshIntervalThenValidationFails() {
+        assertThatThrownBy(() -> properties.setServersRefreshInterval(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Servers refresh interval must be greater then zero");
+    }
+
+    @Test
+    public void whenSetNegativeServersRefreshIntervalThenValidationFails() {
+        assertThatThrownBy(() -> properties.setServersRefreshInterval(Duration.ofDays(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Servers refresh interval must be greater then zero");
+    }
+
+    @Test
+    public void whenSetHashStrategyThenValidationOk() {
+        properties.setHashStrategy(MemcachedCacheProperties.HashStrategy.KETAMA);
+
+        assertThat(properties.getHashStrategy()).isEqualTo(MemcachedCacheProperties.HashStrategy.KETAMA);
+    }
+
+    @Test
+    public void whenSetNullHashStrategyThenValidationOk() {
+        properties.setHashStrategy(null);
+
+        assertThat(properties.getHashStrategy()).isNull();
+    }
+}


### PR DESCRIPTION
In Memcached the expiration times are specified in seconds as unsigned integer value. The expiration can take following values:

1) `0` - never expire
2) `Up to 30 days` i.e. 60x60x24x30 = 2.592.000 seconds 
3) Any value `greater than 30 days` is interpreted as Unix timestamp e.g. can be used to expire cache on specific date.

In order to support expiration values of more than 30 days, the check is performed when obtaining configured expiration when cache client `set()` and `touch()` calls. If the given expiration in seconds is greater than 30 days, we add the expiration value to the current instant of UTC timezone (Unix timestamp). In case expiration is less than or equals to 30 days, we do not perform any recalculation and use the existing expiration for cache client's `set()` and `touch()` calls.

In this way we can continue using the `memcached.cache.expiration` & `memcached.cache.expiration-per-cache` configuration properties as time-to-live value i.e. cache entry expiration. This change will not introduce any breaking change (e.g. expiring cache on specific date), being we did not allow expiration values of more than 30 days.

Resolves #152