### PR TITLE
Add authentication support for memcached client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To plug-in Memcached cache in your application follow the steps below:
         implementation('io.sixhours:memcached-spring-boot-starter:2.4.4') {
           exclude group: 'com.googlecode.xmemcached', module: 'xmemcached'
         }
-        implementation('com.amazonaws:elasticache-java-cluster-client:1.1.2')
+        implementation('com.amazonaws:elasticache-java-cluster-client:1.2.0')
         ```
    * **Maven**
 
@@ -58,7 +58,7 @@ To plug-in Memcached cache in your application follow the steps below:
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>elasticache-java-cluster-client</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.0</version>
         </dependency>
         ```
 
@@ -102,6 +102,26 @@ To plug-in Memcached cache in your application follow the steps below:
         provider: appengine
         expiration: 86400 # default expiration set to '86400' seconds i.e. 1 day
     ```
+
+   If you are using authentication to connect to the memcached server, check the example configuration below.
+   The memcached server has to support the authentication mechanism the client is using. By default, the `plain` 
+   authentication mechanism will be used, but if needed you can switch to `CRAM-MD5` mechanism by setting the 
+   `memcached.cache.authentication.mechanism: cram-md5` property.
+
+   >**Important:** The authentication requires `binary` protocol, therefore make sure that the `memcached.cache.protocol` property has
+been set to `binary`.
+
+    ```yaml
+     memcached.cache:
+       servers: example1.com:11211
+       provider: static
+       # default expiration set to '1d' (1 day i.e. '86400' seconds) and custom ones for cache_name1 and cache_name2
+       expiration: 1d
+       authentication:
+        username: my_user # replace with your memcached server 'username'
+        password: my_password # replace with your memcached server 'password'
+       protocol: binary # required for authentication
+     ```
 
 3. Enable caching support by adding `@EnableCaching` annotation to one of your `@Configuration` classes.
 
@@ -152,6 +172,12 @@ memcached.cache.expiration: # Default cache expiration (defaults to "0", meaning
 memcached.cache.expiration-per-cache.cacheName: # Set expiration for cache with given name. Overrides `memcached.cache.expiration` for the given cache. To set expiration value for cache named "cacheName" {cache_name}:{number} e.g. "authors: 3600" or "authors: 1h". If duration unit is not specified, seconds will be used by default.
 memcached.cache.prefix: # Cache key prefix (default "memcached:spring-boot")
 memcached.cache.protocol: # Memcached client protocol. Supports "text" and "binary" protocols (default is "text" protocol)
+
+# Authentication config properties are not required to be set if authentication is not used
+memcached.cache.authentication.username: # Login username of the memcached server. Requires "binary" protocol.
+memcached.cache.authentication.password: # Login password of the memcached server. Requires "binary" protocol.
+memcached.cache.authentication.mechanism: # Authentication mechanism to be used with memcached server. Defaults to "PLAIN". Supported mechanisms are "PLAIN" and "CRAM-MD5".
+
 memcached.cache.operation-timeout: # Memcached client operation timeout (default "2500 milliseconds"). If unit not specified, milliseconds will be used.
 memcached.cache.hash-strategy: # Memcached client hash strategy for distribution of data between servers. Supports "standard" (array based : "hash(key) mod server_count"), "libmemcached" (consistent hash), "ketama" (consistent hash), "php" (make easier to share data with PHP based clients), "election", "roundrobin", "random". Default is "standard".
 memcached.cache.servers-refresh-interval: # Interval in milliseconds that refreshes the list of cache node hostnames and IP addresses for AWS ElastiCache. The default is 60000 milliseconds.
@@ -181,8 +207,7 @@ Supported units are:
 
 * `d` for days
 
-**Notice:**
->If different applications are sharing the same Memcached server, make sure to specify unique cache `prefix` for each application
+>**Notice:** If different applications are sharing the same Memcached server, make sure to specify unique cache `prefix` for each application
 in order to avoid cache conflicts.
 
 ## Build

--- a/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/MemcachedCacheContextConfigIT.java
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/MemcachedCacheContextConfigIT.java
@@ -55,6 +55,11 @@ public class MemcachedCacheContextConfigIT {
         assertThat(properties.getServers().get(1)).isNotNull();
         assertThat(properties.getServers().get(1).getHostName()).isEqualTo("example2.com");
         assertThat(properties.getServers().get(1).getPort()).isEqualTo(12346);
+        assertThat(properties.getAuthentication()).isNotNull();
+        assertThat(properties.getAuthentication().getUsername()).isEqualTo("test-user");
+        assertThat(properties.getAuthentication().getPassword()).isEqualTo("test-password");
+        assertThat(properties.getAuthentication().getMechanism())
+                .isEqualTo(MemcachedCacheProperties.Authentication.Mechanism.CRAM_MD5);
         assertThat(properties.getServersRefreshInterval()).isEqualTo(Duration.ofSeconds(30));
         assertThat(properties.getOperationTimeout()).isEqualTo(Duration.ofMillis(7200));
         assertThat(properties.getPrefix()).isEqualTo("memcached:test-app");

--- a/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/SpymemcachedAuthenticationIT.java
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/SpymemcachedAuthenticationIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2016-2023 Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sixhours.memcached.cache;
+
+import net.spy.memcached.OperationTimeoutException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+
+import static io.sixhours.memcached.cache.MemcachedAssertions.assertMemcachedCacheManager;
+import static io.sixhours.memcached.cache.MemcachedAssertions.assertSpymemcachedClient;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Spymemcached client authentication integration tests.
+ * <p>
+ * Using bitnami memcached container which supports PLAIN authentication mechanism.
+ */
+@Ignore("Until the https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java/pull/5 issue FIX is " +
+        "released for AWS elasticache-client (1.2.1 version), this test should be ignored, since MemcachedClient initialization will fail with NPE")
+public class SpymemcachedAuthenticationIT {
+
+    @ClassRule
+    public static GenericContainer MEMCACHED_1 = new GenericContainer("bitnami/memcached:latest")
+            .withEnv("MEMCACHED_USERNAME", "my_user")
+            .withEnv("MEMCACHED_PASSWORD", "my_password")
+            .withExposedPorts(11211);
+
+    @ClassRule
+    public static GenericContainer MEMCACHED_2 = new GenericContainer("bitnami/memcached:latest")
+            .withEnv("MEMCACHED_USERNAME", "my_user")
+            .withEnv("MEMCACHED_PASSWORD", "my_password")
+            .withExposedPorts(11211);
+
+    private final AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+
+    private String memcachedHost1;
+    private int memcachedPort1;
+
+    private String memcachedHost2;
+    private int memcachedPort2;
+
+    @Before
+    public void setUp() {
+        memcachedHost1 = MEMCACHED_1.getHost();
+        memcachedPort1 = MEMCACHED_1.getFirstMappedPort();
+
+        memcachedHost2 = MEMCACHED_2.getHost();
+        memcachedPort2 = MEMCACHED_2.getFirstMappedPort();
+    }
+
+    @After
+    public void tearDown() {
+        applicationContext.close();
+    }
+
+    @Test
+    public void whenTextProtocolAndCredentialsThenMemcachedClientFails() {
+        loadContext(
+                "memcached.cache.protocol=text",
+                "memcached.cache.authentication.username=my_user",
+                "memcached.cache.authentication.password=my_password"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Should fail to get key due to using TEXT protocol with credentials
+        assertThatThrownBy(() -> memcachedClient.get("key"))
+                .isInstanceOf(OperationTimeoutException.class)
+                .hasMessageStartingWith("Timeout waiting for value: waited 2,500 ms.")
+                .getRootCause()
+                .hasMessageStartingWith("Timed out waiting for operation - failing node: /");
+
+        assertSpymemcachedClient(memcachedClient, Default.OPERATION_TIMEOUT, new InetSocketAddress(memcachedHost1, memcachedPort1), new InetSocketAddress(memcachedHost2, memcachedPort2));
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    @Test
+    public void whenBinaryProtocolAndCredentialsThenMemcachedClientSuccessful() {
+        loadContext(
+                "memcached.cache.protocol=binary",
+                "memcached.cache.authentication.username=my_user",
+                "memcached.cache.authentication.password=my_password"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Client should be able to access memcached, and return null value for non-existing key
+        Object value = memcachedClient.get("key");
+        assertThat(value).isNull();
+
+
+        assertSpymemcachedClient(memcachedClient, Default.OPERATION_TIMEOUT, new InetSocketAddress(memcachedHost1, memcachedPort1), new InetSocketAddress(memcachedHost2, memcachedPort2));
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    @Test
+    public void whenBinaryProtocolAndIncorrectCredentialsThenMemcachedNotLoaded() {
+        loadContext(
+                "memcached.cache.protocol=binary",
+                "memcached.cache.authentication.username=my_user_incorrect",
+                "memcached.cache.authentication.password=my_password"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Should fail to get key due to incorrect credentials i.e. no available connections
+        assertThatThrownBy(() -> memcachedClient.get("key"))
+                .isInstanceOf(OperationTimeoutException.class)
+                .hasMessageStartingWith("Timeout waiting for value: waited 2,500 ms.")
+                .getRootCause()
+                .hasMessageStartingWith("Timed out waiting for operation - failing node: <unknown>");
+
+        // There should be no available server for client
+        assertSpymemcachedClient(memcachedClient, Default.OPERATION_TIMEOUT);
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    private void loadContext(String... environment) {
+        TestPropertyValues.of(environment).applyTo(applicationContext);
+        TestPropertyValues.of(
+                String.format("memcached.cache.servers=%s:%d, %s:%d", memcachedHost1, memcachedPort1, memcachedHost2, memcachedPort2),
+                "memcached.cache.provider=static"
+        ).applyTo(applicationContext);
+
+        applicationContext.register(CacheConfiguration.class);
+        applicationContext.register(SpyMemcachedCacheAutoConfiguration.class);
+        applicationContext.register(CacheAutoConfiguration.class);
+        applicationContext.refresh();
+    }
+
+    @Configuration
+    @EnableCaching
+    @EnableConfigurationProperties(MemcachedCacheProperties.class)
+    static class CacheConfiguration {
+
+        @Bean
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties) throws IOException {
+            return new SpyMemcachedCacheManagerFactory(properties, builder -> {
+            }).create();
+        }
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/XMemcachedAuthenticationIT.java
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/XMemcachedAuthenticationIT.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2016-2023 Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.sixhours.memcached.cache;
+
+import io.sixhours.memcached.cache.MemcachedCacheProperties.Protocol;
+import net.rubyeye.xmemcached.exception.MemcachedException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
+
+import static io.sixhours.memcached.cache.MemcachedAssertions.assertMemcachedCacheManager;
+import static io.sixhours.memcached.cache.MemcachedAssertions.assertMemcachedClient;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * XMemcached client authentication integration tests.
+ * <p>
+ * Using bitnami memcached container which supports PLAIN authentication mechanism.
+ */
+public class XMemcachedAuthenticationIT {
+
+    @ClassRule
+    public static GenericContainer MEMCACHED_1 = new GenericContainer("bitnami/memcached:latest")
+            .withEnv("MEMCACHED_USERNAME", "my_user")
+            .withEnv("MEMCACHED_PASSWORD", "my_password")
+            .withExposedPorts(11211);
+
+    @ClassRule
+    public static GenericContainer MEMCACHED_2 = new GenericContainer("bitnami/memcached:latest")
+            .withEnv("MEMCACHED_USERNAME", "my_user")
+            .withEnv("MEMCACHED_PASSWORD", "my_password")
+            .withExposedPorts(11211);
+
+    private final AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+
+    private String memcachedHost1;
+    private int memcachedPort1;
+
+    private String memcachedHost2;
+    private int memcachedPort2;
+
+    @Before
+    public void setUp() {
+        memcachedHost1 = MEMCACHED_1.getHost();
+        memcachedPort1 = MEMCACHED_1.getFirstMappedPort();
+
+        memcachedHost2 = MEMCACHED_2.getHost();
+        memcachedPort2 = MEMCACHED_2.getFirstMappedPort();
+    }
+
+    @After
+    public void tearDown() {
+        applicationContext.close();
+    }
+
+    @Test
+    public void whenTextProtocolAndCredentialsThenMemcachedClientFails() {
+        loadContext(
+                "memcached.cache.protocol=text",
+                "memcached.cache.authentication.username=my_user",
+                "memcached.cache.authentication.password=my_password",
+                "memcached.cache.authentication.mechanism=plain"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Should fail to get key due to using TEXT protocol with credentials
+        assertThatThrownBy(() -> memcachedClient.get("key"))
+                .isInstanceOf(MemcachedOperationException.class)
+                .hasMessage("Failed to get key")
+                .getRootCause()
+                .isInstanceOf(TimeoutException.class);
+
+        assertMemcachedClient(memcachedClient, Protocol.TEXT, Default.OPERATION_TIMEOUT, new InetSocketAddress(memcachedHost1, memcachedPort1), new InetSocketAddress(memcachedHost2, memcachedPort2));
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    @Test
+    public void whenBinaryProtocolAndCredentialsThenMemcachedClientSuccessful() {
+        loadContext(
+                "memcached.cache.protocol=binary",
+                "memcached.cache.authentication.username=my_user",
+                "memcached.cache.authentication.password=my_password",
+                "memcached.cache.authentication.mechanism=plain"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Client should be able to access memcached, and return null value for non-existing key
+        Object value = memcachedClient.get("key");
+        assertThat(value).isNull();
+
+        assertMemcachedClient(memcachedClient, Protocol.BINARY, Default.OPERATION_TIMEOUT, new InetSocketAddress(memcachedHost1, memcachedPort1), new InetSocketAddress(memcachedHost2, memcachedPort2));
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    @Test
+    public void whenUnsupportedMechanismThenMemcachedNotLoaded() {
+        loadContext(
+                "memcached.cache.protocol=binary",
+                "memcached.cache.authentication.username=my_user",
+                "memcached.cache.authentication.password=my_password",
+                "memcached.cache.authentication.mechanism=cram-md5"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Should fail to get key due to incorrect credentials i.e. no available connections
+        assertThatThrownBy(() -> memcachedClient.get("key"))
+                .isInstanceOf(MemcachedOperationException.class)
+                .hasMessage("Failed to get key")
+                .getRootCause()
+                .isInstanceOf(MemcachedException.class);
+
+        assertMemcachedClient(memcachedClient, Protocol.BINARY, Default.OPERATION_TIMEOUT);
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    @Test
+    public void whenBinaryProtocolAndIncorrectCredentialsThenMemcachedNotLoaded() {
+        loadContext(
+                "memcached.cache.protocol=binary",
+                "memcached.cache.authentication.username=my_user_incorrect",
+                "memcached.cache.authentication.password=my_password",
+                "memcached.cache.authentication.mechanism=plain"
+        );
+
+        MemcachedCacheManager memcachedCacheManager = this.applicationContext.getBean(MemcachedCacheManager.class);
+        IMemcachedClient memcachedClient = memcachedCacheManager.memcachedClient;
+
+        // Should fail to get key due to incorrect credentials i.e. no available connections
+        assertThatThrownBy(() -> memcachedClient.get("key"))
+                .isInstanceOf(MemcachedOperationException.class)
+                .hasMessage("Failed to get key")
+                .getRootCause()
+                .isInstanceOf(MemcachedException.class);
+
+        // There should be no available server for client
+        assertMemcachedClient(memcachedClient, Protocol.BINARY, Default.OPERATION_TIMEOUT);
+        assertMemcachedCacheManager(memcachedCacheManager, Default.EXPIRATION, Collections.emptyMap(), Default.PREFIX, Default.NAMESPACE);
+    }
+
+    private void loadContext(String... environment) {
+        TestPropertyValues.of(environment).applyTo(applicationContext);
+        TestPropertyValues.of(
+                String.format("memcached.cache.servers=%s:%d, %s:%d", memcachedHost1, memcachedPort1, memcachedHost2, memcachedPort2),
+                "memcached.cache.provider=static"
+        ).applyTo(applicationContext);
+
+        applicationContext.register(CacheConfiguration.class);
+        applicationContext.register(MemcachedCacheAutoConfiguration.class);
+        applicationContext.register(CacheAutoConfiguration.class);
+        applicationContext.refresh();
+    }
+
+    @Configuration
+    @EnableCaching
+    static class CacheConfiguration {
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/integration-test/resources/application.yml
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/resources/application.yml
@@ -16,6 +16,10 @@
 
 memcached.cache:
   servers: example1.com:12345,example2.com:12346
+  authentication:
+    username: test-user
+    password: test-password
+    mechanism: cram-md5
   servers-refresh-interval: 30000
   operation-timeout: 7200
   prefix: memcached:test-app

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/Default.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/Default.java
@@ -15,6 +15,8 @@
  */
 package io.sixhours.memcached.cache;
 
+import io.sixhours.memcached.cache.MemcachedCacheProperties.Authentication;
+import io.sixhours.memcached.cache.MemcachedCacheProperties.Authentication.Mechanism;
 import io.sixhours.memcached.cache.MemcachedCacheProperties.HashStrategy;
 import io.sixhours.memcached.cache.MemcachedCacheProperties.Provider;
 
@@ -33,6 +35,10 @@ import static java.util.Collections.singletonList;
 public final class Default {
 
     public static final List<InetSocketAddress> SERVERS = singletonList(new InetSocketAddress("localhost", 11211));
+
+    public static final Authentication AUTHENTICATION = new Authentication();
+
+    public static final Mechanism AUTHENTICATION_MECHANISM = Mechanism.PLAIN;
 
     public static final Provider PROVIDER = Provider.STATIC;
 

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/MemcachedCacheProperties.java
@@ -46,6 +46,12 @@ public class MemcachedCacheProperties {
     private List<InetSocketAddress> servers = Default.SERVERS;
 
     /**
+     * Authentication configuration values. Requires binary protocol if used.
+     * Defaults to empty authentication configuration.
+     */
+    private Authentication authentication = Default.AUTHENTICATION;
+
+    /**
      * Comma-separated list of cache names to disable
      */
     private Set<String> disabledCacheNames = new HashSet<>();
@@ -122,6 +128,14 @@ public class MemcachedCacheProperties {
                 .map(SocketAddress::new)
                 .map(SocketAddress::value)
                 .collect(Collectors.toList());
+    }
+
+    public Authentication getAuthentication() {
+        return authentication;
+    }
+
+    public void setAuthentication(Authentication authentication) {
+        this.authentication = authentication;
     }
 
     public Set<String> getDisabledCacheNames() {
@@ -221,6 +235,69 @@ public class MemcachedCacheProperties {
 
     public void setHashStrategy(HashStrategy hashStrategy) {
         this.hashStrategy = hashStrategy;
+    }
+
+    public static class Authentication {
+
+        /**
+         * Login username of the memcached server.
+         */
+        private String username;
+
+        /**
+         * Login password of the memcached server.
+         */
+        private String password;
+
+        /**
+         * Authentication mechanisms to be used for login negotiation.
+         */
+        private Mechanism mechanism;
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public Mechanism getMechanism() {
+            return mechanism != null ? mechanism : Default.AUTHENTICATION_MECHANISM;
+        }
+
+        public void setMechanism(Mechanism mechanism) {
+            this.mechanism = mechanism;
+        }
+
+        public boolean isEmpty() {
+            return username == null || password == null;
+        }
+
+        /**
+         * Supported authentication mechanisms.
+         */
+        public enum Mechanism {
+            PLAIN("PLAIN"), CRAM_MD5("CRAM-MD5");
+
+            private final String value;
+
+            Mechanism(String value) {
+                this.value = value;
+            }
+
+            public String asString() {
+                return value;
+            }
+        }
     }
 
     public enum Protocol {

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesDefaultValuesTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesDefaultValuesTest.java
@@ -64,6 +64,17 @@ public class MemcachedCachePropertiesDefaultValuesTest {
     }
 
     @Test
+    public void whenGetAuthentication_thenNullValue() {
+        MemcachedCacheProperties.Authentication result = memcachedCacheProperties.getAuthentication();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getUsername()).isNull();
+        assertThat(result.getPassword()).isNull();
+        assertThat(result.getMechanism())
+                .isEqualTo(MemcachedCacheProperties.Authentication.Mechanism.PLAIN);
+    }
+
+    @Test
     public void whenGetPrefix_thenCorrectValue() {
         String result = memcachedCacheProperties.getPrefix();
 

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesTest.java
@@ -68,6 +68,34 @@ public class MemcachedCachePropertiesTest {
     }
 
     @Test
+    public void whenGetAuthenticationUsername_thenCorrectValue() {
+        String result = memcachedCacheProperties.getAuthentication().getUsername();
+
+        assertThat(result)
+                .isNotNull()
+                .isEqualTo("user_config");
+    }
+
+    @Test
+    public void whenGetAuthenticationPassword_thenCorrectValue() {
+        String result = memcachedCacheProperties.getAuthentication().getPassword();
+
+        assertThat(result)
+                .isNotNull()
+                .isEqualTo("pwd_config");
+    }
+
+    @Test
+    public void whenGetAuthenticationMechanism_thenCorrectValue() {
+        MemcachedCacheProperties.Authentication.Mechanism result =
+                memcachedCacheProperties.getAuthentication().getMechanism();
+
+        assertThat(result)
+                .isNotNull()
+                .isEqualTo(MemcachedCacheProperties.Authentication.Mechanism.PLAIN);
+    }
+
+    @Test
     public void whenGetPrefix_thenCorrectValue() {
         String result = memcachedCacheProperties.getPrefix();
 

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesValidationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedCachePropertiesValidationTest.java
@@ -71,6 +71,38 @@ public class MemcachedCachePropertiesValidationTest {
     }
 
     @Test
+    public void whenSetAuthenticationThenValidationOk() {
+        MemcachedCacheProperties.Authentication authentication = new MemcachedCacheProperties.Authentication();
+        authentication.setUsername("test-user");
+        authentication.setPassword("test-pwd");
+        authentication.setMechanism(MemcachedCacheProperties.Authentication.Mechanism.CRAM_MD5);
+
+        properties.setAuthentication(authentication);
+
+        assertThat(properties.getAuthentication()).isNotNull();
+        assertThat(properties.getAuthentication().getUsername()).isEqualTo("test-user");
+        assertThat(properties.getAuthentication().getPassword()).isEqualTo("test-pwd");
+        assertThat(properties.getAuthentication().getMechanism())
+                .isEqualTo(MemcachedCacheProperties.Authentication.Mechanism.CRAM_MD5);
+    }
+
+    @Test
+    public void whenSetAuthenticationWithNullValuesThenValidationOk() {
+        MemcachedCacheProperties.Authentication authentication = new MemcachedCacheProperties.Authentication();
+        authentication.setUsername(null);
+        authentication.setPassword(null);
+        authentication.setMechanism(null);
+
+        properties.setAuthentication(authentication);
+
+        assertThat(properties.getAuthentication()).isNotNull();
+        assertThat(properties.getAuthentication().getUsername()).isNull();
+        assertThat(properties.getAuthentication().getPassword()).isNull();
+        assertThat(properties.getAuthentication().getMechanism())
+                .isEqualTo(MemcachedCacheProperties.Authentication.Mechanism.PLAIN);
+    }
+
+    @Test
     public void whenSetDisabledCacheNamesThenValidationOk() {
         Set<String> names = new HashSet<>();
         names.add("cache-1");

--- a/memcached-spring-boot-autoconfigure/src/test/resources/application-config-test.yml
+++ b/memcached-spring-boot-autoconfigure/src/test/resources/application-config-test.yml
@@ -18,6 +18,10 @@ memcached.cache:
   servers: example1.com:12345,example2.com:12346
   servers-refresh-interval: 30000
   operation-timeout: 7200
+  authentication:
+    username: user_config
+    password: pwd_config
+    mechanism: plain
   prefix: memcached:my-app
   protocol: binary
   provider: aws


### PR DESCRIPTION
Memcached supports authentication via BINARY protocol. Therefore, it is mandatory for existing user to switch from TEXT to BINARY protocol in case they start using authentication support.

The memcached server should support at least one of authentication mechanisms: PLAIN or CRAM-MD5, as these are the mechanisms that Spymemcached and XMemcached clients support for typical authentication.

Resolves #126