### PR TITLE
Use sonar with Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
           - java: 8
             sonar: false
           - java: 11
-            sonar: true
-          - java: 17
             sonar: false
+          - java: 17
+            sonar: true
     name: Build
     # Skip main build (JDK versions build) once the pull request is merged into master.
     # Once PR is merged the release-snapshot action should handle the SNAPSHOT


### PR DESCRIPTION
Sonar scanners do not support Java 11 anymore, but Java 17