### PR TITLE
Add support for customizing the `XMemcachedClient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,74 @@ Supported units are:
 
 * `d` for days
 
->**Notice:** If different applications are sharing the same Memcached server, make sure to specify unique cache `prefix` for each application
-in order to avoid cache conflicts.
+> **Notice:** If different applications are sharing the same Memcached server, make sure to specify unique cache `prefix` for each application
+> in order to avoid cache conflicts.
+
+## Customizing Memcached Clients
+
+The `memcached.cache` application [properties](#properties) cover the most common configuration options shared across all supported
+clients, such as connection setup, timeouts, and basic client behavior.
+
+[Spymemcached](https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java)
+and [Xmemcached](https://github.com/killme2008/xmemcached) clients also expose additional low-level options (such as
+connection handling, failure strategies, etc.) that are not available through these properties.
+
+If you need more control, you can use client-specific customizer beans. These are applied during Spring Boot
+auto-configuration while the client is being created and let you adjust the underlying builder before the client is
+instantiated. This allows you to add settings not exposed via `memcached.cache` or override existing ones when needed.
+
+### SpyMemcachedClient
+
+You can customize
+the [SpyMemcachedClient](memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedClient.java)
+by defining
+a [SpyMemcachedConnectionFactoryCustomizer](memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedConnectionFactoryCustomizer.java)
+bean. Any such customizer bean is called with the `net.spy.memcached.ConnectionFactoryBuilder`, which is used internally
+to construct the client.
+This allows fine-grained control over the underlying client settings, including failure handling, reconnect behavior,
+and operation tuning, for example:
+
+```java
+
+@Bean
+public SpyMemcachedConnectionFactoryCustomizer customizer() {
+    return builder -> {
+        builder.setMaxReconnectDelay(1000);
+        builder.setFailureMode(FailureMode.Retry);
+
+        // overrides 'memcached.cache.operation-timeout' value
+        // if already specified in application properties
+        builder.setOpTimeout(1200);
+    };
+}
+```
+
+### XMemcachedClient
+
+You can customize
+the [XMemcachedClient](memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedClient.java)
+by defining
+an [XMemcachedClientCustomizer](memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedClientCustomizer.java)
+bean. Any such customizer bean is called with the `net.rubyeye.xmemcached.MemcachedClientBuilder`, which is used internally
+to construct the client.
+This allows fine-grained control over the underlying client settings, including connection pooling, timeouts, and other
+advanced client features, for example:
+
+```java
+
+@Bean
+public XMemcachedClientCustomizer customizer() {
+    return builder -> {
+        builder.setConnectionPoolSize(123);
+        builder.setConnectTimeout(5000);
+        builder.setFailureMode(true);
+
+        // overrides 'memcached.cache.operation-timeout' value
+        // if already specified in application properties
+        builder.setOpTimeout(1200);
+    };
+}
+```
 
 ## Build
 

--- a/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/SpymemcachedAuthenticationIT.java
+++ b/memcached-spring-boot-autoconfigure/src/integration-test/java/io/sixhours/memcached/cache/SpymemcachedAuthenticationIT.java
@@ -167,8 +167,7 @@ public class SpymemcachedAuthenticationIT {
 
         @Bean
         public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties) throws IOException {
-            return new SpyMemcachedCacheManagerFactory(properties, builder -> {
-            }).create();
+            return new SpyMemcachedCacheManagerFactory(properties, null).create();
         }
     }
 }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.sixhours.memcached.cache;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -49,8 +50,8 @@ public class SpyMemcachedCacheAutoConfiguration {
         @Bean
         @RefreshScope
         @ConditionalOnMissingBean(value = MemcachedCacheManager.class, search = SearchStrategy.CURRENT)
-        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, SpyMemcachedConnectionFactoryCustomizer customizer) throws IOException {
-            return new SpyMemcachedCacheManagerFactory(properties, customizer).create();
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, ObjectProvider<SpyMemcachedConnectionFactoryCustomizer> customizers) throws IOException {
+            return new SpyMemcachedCacheManagerFactory(properties, customizers).create();
         }
     }
 
@@ -60,14 +61,8 @@ public class SpyMemcachedCacheAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean(value = MemcachedCacheManager.class, search = SearchStrategy.CURRENT)
-        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, SpyMemcachedConnectionFactoryCustomizer customizer) throws IOException {
-            return new SpyMemcachedCacheManagerFactory(properties, customizer).create();
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, ObjectProvider<SpyMemcachedConnectionFactoryCustomizer> customizers) throws IOException {
+            return new SpyMemcachedCacheManagerFactory(properties, customizers).create();
         }
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(value = SpyMemcachedConnectionFactoryCustomizer.class)
-    public SpyMemcachedConnectionFactoryCustomizer spyMemcachedConnectionFactoryCustomizer() {
-        return (builder) -> {};
     }
 }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheManagerFactory.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/SpyMemcachedCacheManagerFactory.java
@@ -20,6 +20,7 @@ import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.PlainCallbackHandler;
+import org.springframework.beans.factory.ObjectProvider;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -32,11 +33,11 @@ import java.util.List;
  */
 public class SpyMemcachedCacheManagerFactory extends MemcachedCacheManagerFactory {
 
-    private final SpyMemcachedConnectionFactoryCustomizer connectionFactoryCustomizer;
+    private final ObjectProvider<SpyMemcachedConnectionFactoryCustomizer> customizers;
 
-    public SpyMemcachedCacheManagerFactory(MemcachedCacheProperties properties, SpyMemcachedConnectionFactoryCustomizer customizer) {
+    public SpyMemcachedCacheManagerFactory(MemcachedCacheProperties properties, ObjectProvider<SpyMemcachedConnectionFactoryCustomizer> customizers) {
         super(properties);
-        this.connectionFactoryCustomizer = customizer;
+        this.customizers = customizers;
     }
 
     @Override
@@ -64,7 +65,7 @@ public class SpyMemcachedCacheManagerFactory extends MemcachedCacheManagerFactor
             );
         }
 
-        connectionFactoryCustomizer.customize(connectionFactoryBuilder);
+        customizers.orderedStream().forEach(customizer -> customizer.customize(connectionFactoryBuilder));
 
         return new SpyMemcachedClient(new MemcachedClient(connectionFactoryBuilder.build(), servers));
     }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedCacheAutoConfiguration.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedCacheAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.sixhours.memcached.cache;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -50,8 +51,8 @@ public class XMemcachedCacheAutoConfiguration {
         @Bean
         @RefreshScope
         @ConditionalOnMissingBean(value = MemcachedCacheManager.class, search = SearchStrategy.CURRENT)
-        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties) throws IOException {
-            return new XMemcachedCacheManagerFactory(properties).create();
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, ObjectProvider<XMemcachedClientCustomizer> customizers) throws IOException {
+            return new XMemcachedCacheManagerFactory(properties, customizers).create();
         }
     }
 
@@ -61,8 +62,8 @@ public class XMemcachedCacheAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean(value = MemcachedCacheManager.class, search = SearchStrategy.CURRENT)
-        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties) throws IOException {
-            return new XMemcachedCacheManagerFactory(properties).create();
+        public MemcachedCacheManager cacheManager(MemcachedCacheProperties properties, ObjectProvider<XMemcachedClientCustomizer> customizers) throws IOException {
+            return new XMemcachedCacheManagerFactory(properties, customizers).create();
         }
     }
 }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedCacheManagerFactory.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedCacheManagerFactory.java
@@ -31,6 +31,7 @@ import net.rubyeye.xmemcached.impl.LibmemcachedMemcachedSessionLocator;
 import net.rubyeye.xmemcached.impl.PHPMemcacheSessionLocator;
 import net.rubyeye.xmemcached.impl.RandomMemcachedSessionLocaltor;
 import net.rubyeye.xmemcached.impl.RoundRobinMemcachedSessionLocator;
+import org.springframework.beans.factory.ObjectProvider;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -47,8 +48,11 @@ import java.util.stream.Collectors;
  */
 public class XMemcachedCacheManagerFactory extends MemcachedCacheManagerFactory {
 
-    public XMemcachedCacheManagerFactory(MemcachedCacheProperties properties) {
+    private final ObjectProvider<XMemcachedClientCustomizer> customizers;
+
+    public XMemcachedCacheManagerFactory(MemcachedCacheProperties properties, ObjectProvider<XMemcachedClientCustomizer> customizers) {
         super(properties);
+        this.customizers = customizers;
     }
 
     @Override
@@ -83,6 +87,8 @@ public class XMemcachedCacheManagerFactory extends MemcachedCacheManagerFactory 
         builder.setSessionLocator(hashStrategyToLocator(hashStrategy));
         builder.setOpTimeout(properties.getOperationTimeout().toMillis());
         builder.setCommandFactory(commandFactory(protocol));
+
+        customizers.orderedStream().forEach(customizer -> customizer.customize(builder));
 
         return new XMemcachedClient(builder.build());
     }

--- a/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedClientCustomizer.java
+++ b/memcached-spring-boot-autoconfigure/src/main/java/io/sixhours/memcached/cache/XMemcachedClientCustomizer.java
@@ -15,19 +15,19 @@
  */
 package io.sixhours.memcached.cache;
 
-import net.spy.memcached.ConnectionFactoryBuilder;
+import net.rubyeye.xmemcached.MemcachedClientBuilder;
 
 /**
- * A customizer interface for beans that want to adjust the {@link ConnectionFactoryBuilder}, allowing fine-tuning of the
- * auto-configuration before creating a {@link net.spy.memcached.MemcachedClient}.
+ * A customizer interface for beans that want to adjust the {@link MemcachedClientBuilder}, allowing fine-tuning of the
+ * auto-configuration before creating a {@link net.rubyeye.xmemcached.MemcachedClient}.
  */
 @FunctionalInterface
-public interface SpyMemcachedConnectionFactoryCustomizer {
+public interface XMemcachedClientCustomizer {
 
     /**
-     * Customize the given {@link ConnectionFactoryBuilder}.
+     * Customize the given {@link MemcachedClientBuilder}.
      *
      * @param builder the builder
      */
-    void customize(ConnectionFactoryBuilder builder);
+    void customize(MemcachedClientBuilder builder);
 }

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedAutoConfigurationTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/MemcachedAutoConfigurationTest.java
@@ -15,7 +15,18 @@
  */
 package io.sixhours.memcached.cache;
 
-import net.rubyeye.xmemcached.impl.*;
+import net.rubyeye.xmemcached.MemcachedClient;
+import net.rubyeye.xmemcached.command.KestrelCommandFactory;
+import net.rubyeye.xmemcached.impl.ArrayMemcachedSessionLocator;
+import net.rubyeye.xmemcached.impl.ElectionMemcachedSessionLocator;
+import net.rubyeye.xmemcached.impl.KetamaMemcachedSessionLocator;
+import net.rubyeye.xmemcached.impl.LibmemcachedMemcachedSessionLocator;
+import net.rubyeye.xmemcached.impl.MemcachedConnector;
+import net.rubyeye.xmemcached.impl.PHPMemcacheSessionLocator;
+import net.rubyeye.xmemcached.impl.RandomMemcachedSessionLocaltor;
+import net.rubyeye.xmemcached.impl.RoundRobinMemcachedSessionLocator;
+import net.rubyeye.xmemcached.utils.Protocol;
+import net.spy.memcached.FailureMode;
 import org.junit.Test;
 import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.BeanCreationException;
@@ -174,7 +185,7 @@ public class MemcachedAutoConfigurationTest {
         this.contextRunner.withUserConfiguration(CacheConfiguration.class)
                 .withPropertyValues("memcached.cache.provider=appengine")
                 .withClassLoader(new FilteredClassLoader("com.google.appengine.api.memcache"))
-                .run(context ->  assertThat(context).doesNotHaveBean(MemcachedCacheManager.class));
+                .run(context -> assertThat(context).doesNotHaveBean(MemcachedCacheManager.class));
     }
 
     @Test
@@ -191,15 +202,88 @@ public class MemcachedAutoConfigurationTest {
     }
 
     @Test
-    public void whenXmemcachedOnClasspathThenSpymemcachedLoaded() {
+    public void whenXmemcachedNotOnClasspathThenSpymemcachedLoaded() {
         this.contextRunner.withUserConfiguration(CacheConfiguration.class)
                 .withClassLoader(new FilteredClassLoader("net.rubyeye.xmemcached"))
                 .run(context -> {
                     CacheManager cacheManager = cacheManager(context, CacheManager.class);
+
                     assertThat(cacheManager).isInstanceOf(DisposableMemcachedCacheManager.class)
-                            .hasFieldOrProperty("memcachedClient");
-                    assertThat(((DisposableMemcachedCacheManager) cacheManager).memcachedClient)
-                            .isInstanceOf(SpyMemcachedClient.class);
+                            .hasFieldOrProperty("memcachedClient")
+                            .extracting("memcachedClient")
+                            .isInstanceOfSatisfying(SpyMemcachedClient.class, (memcachedClient) -> {
+                                assertThat(memcachedClient.nativeClient())
+                                        .isInstanceOfSatisfying(net.spy.memcached.MemcachedClient.class, (client) -> {
+                                            assertThat(client.getNodeLocator().getAll()).isNotEmpty();
+                                            assertThat(client.getOperationTimeout()).isEqualTo(2500);
+                                        });
+                            });
+                });
+    }
+
+    @Test
+    public void whenXMemcachedNotOnClasspathThenSpymemcachedLoadedAndCustomizerApplied() {
+        this.contextRunner.withUserConfiguration(CacheWithSpyMemcachedClientCustomizerConfiguration.class)
+                .withClassLoader(new FilteredClassLoader("net.rubyeye.xmemcache"))
+                .run(context -> {
+                    CacheManager cacheManager = cacheManager(context, CacheManager.class);
+
+                    assertThat(cacheManager).isInstanceOf(DisposableMemcachedCacheManager.class)
+                            .hasFieldOrProperty("memcachedClient")
+                            .extracting("memcachedClient")
+                            .isInstanceOfSatisfying(SpyMemcachedClient.class, (memcachedClient) -> {
+                                assertThat(memcachedClient.nativeClient())
+                                        .isInstanceOfSatisfying(net.spy.memcached.MemcachedClient.class, (client) -> {
+                                            assertThat(client.getNodeLocator().getAll()).isNotEmpty();
+                                            assertThat(client.getOperationTimeout()).isEqualTo(1200);
+                                        });
+                            });
+                });
+    }
+
+    @Test
+    public void whenSpyMemcachedNotOnClasspathThenXMemcachedClientLoaded() {
+        this.contextRunner.withUserConfiguration(CacheConfiguration.class)
+                .withClassLoader(new FilteredClassLoader("net.spy.memcached"))
+                .run(context -> {
+                    CacheManager cacheManager = cacheManager(context, CacheManager.class);
+
+                    assertThat(cacheManager).isInstanceOf(DisposableMemcachedCacheManager.class)
+                            .hasFieldOrProperty("memcachedClient")
+                            .extracting("memcachedClient")
+                            .isInstanceOfSatisfying(XMemcachedClient.class, (memcachedClient) -> assertThat(memcachedClient.nativeClient()).isInstanceOfSatisfying(MemcachedClient.class, (client) -> {
+                                assertThat(client.getName()).startsWith("MemcachedClient-");
+                                assertThat(client.getOpTimeout()).isEqualTo(2500);
+                                assertThat(client.getConnector()).isInstanceOfSatisfying(MemcachedConnector.class, (connector) -> {
+                                    assertThat(connector).extracting("connectionPoolSize").isEqualTo(1);
+                                    assertThat(connector.getProtocol()).isEqualTo(Protocol.Text);
+                                });
+                                assertThat(client.getConnectTimeout()).isEqualTo(60000);
+                                assertThat(client.isFailureMode()).isFalse();
+                            }));
+                });
+    }
+
+    @Test
+    public void whenSpyMemcachedNotOnClasspathThenXMemcachedClientLoadedAndCustomizerApplied() {
+        this.contextRunner.withUserConfiguration(CacheWithXMemcachedClientCustomizerConfiguration.class)
+                .withClassLoader(new FilteredClassLoader("net.spy.memcached"))
+                .run(context -> {
+                    CacheManager cacheManager = cacheManager(context, CacheManager.class);
+
+                    assertThat(cacheManager).isInstanceOf(DisposableMemcachedCacheManager.class)
+                            .hasFieldOrProperty("memcachedClient")
+                            .extracting("memcachedClient")
+                            .isInstanceOfSatisfying(XMemcachedClient.class, (memcachedClient) -> assertThat(memcachedClient.nativeClient()).isInstanceOfSatisfying(MemcachedClient.class, (client) -> {
+                                assertThat(client.getName()).isEqualTo("customizer");
+                                assertThat(client.getOpTimeout()).isEqualTo(1200);
+                                assertThat(client.getConnector()).isInstanceOfSatisfying(MemcachedConnector.class, (connector) -> {
+                                    assertThat(connector).extracting("connectionPoolSize").isEqualTo(123);
+                                    assertThat(connector.getProtocol()).isEqualTo(Protocol.Kestrel);
+                                });
+                                assertThat(client.getConnectTimeout()).isEqualTo(5000);
+                                assertThat(client.isFailureMode()).isTrue();
+                            }));
                 });
     }
 
@@ -351,6 +435,35 @@ public class MemcachedAutoConfigurationTest {
             IMemcachedClient memcachedClient = mock(IMemcachedClient.class);
 
             return new MemcachedCacheManager(memcachedClient);
+        }
+    }
+
+    @Configuration
+    static class CacheWithSpyMemcachedClientCustomizerConfiguration extends CacheConfiguration {
+
+        @Bean
+        public SpyMemcachedConnectionFactoryCustomizer customizer() {
+            return builder -> {
+                builder.setOpTimeout(1200);
+                builder.setMaxReconnectDelay(1000);
+                builder.setFailureMode(FailureMode.Retry);
+            };
+        }
+    }
+
+    @Configuration
+    static class CacheWithXMemcachedClientCustomizerConfiguration extends CacheConfiguration {
+
+        @Bean
+        public XMemcachedClientCustomizer customizer() {
+            return builder -> {
+                builder.setName("customizer");
+                builder.setOpTimeout(1200);
+                builder.setConnectionPoolSize(123);
+                builder.setConnectTimeout(5000);
+                builder.setCommandFactory(new KestrelCommandFactory());
+                builder.setFailureMode(true);
+            };
         }
     }
 


### PR DESCRIPTION
Besides configuring the Memcached client through application properties, the `XMemcachedClientCustomizer` should allow users to fine-tune the `XMemcachedClient` with their own configuration. This gives users more flexibility when the default Memcached client configuration options are not sufficient for a specific use case.

Resolves: #180