### PR TITLE
Use Spotless for license headers and code formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Check code formatting
+        run: |
+          ./gradlew spotlessCheck
       - name: Execute Gradle build
         run: |
           echo "Build Branch => Branch [$GITHUB_REF_NAME]"

--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ To install the modules in the local Maven repository:
 
     ./gradlew clean build publishToMavenLocal
 
+## Code style
+
+The CI pipeline uses the [Spotless] Gradle plugin to enforce license headers and code formatting standards.
+Before submitting changes, format your code by running:
+
+```bash
+./gradlew spotlessApply
+```
+
 ## License
 
 Memcached Spring Boot is an Open Source software released under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
     id 'org.springframework.boot' version '2.3.0.RELEASE' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
-    id 'com.github.hierynomus.license' version '0.16.1'
+    id 'com.diffplug.spotless' version '8.4.0'
     id 'org.sonarqube' version '6.0.1.5171'
     id 'com.github.ben-manes.versions' version '0.46.0'
 }
@@ -19,7 +19,7 @@ ext {
 }
 
 ext.JAVA_GRADLE = "$rootDir/gradle/java.gradle"
-ext.LICENSE_GRADLE = "$rootDir/gradle/license.gradle"
+ext.SPOTLESS_GRADLE = "$rootDir/gradle/spotless.gradle"
 ext.PUBLISH_GRADLE = "$rootDir/gradle/publish.gradle"
 ext.RELEASE_GRADLE = "$rootDir/gradle/release.gradle"
 ext.SONAR_GRADLE = "$rootDir/gradle/sonar.gradle"
@@ -47,7 +47,7 @@ apply from: RELEASE_GRADLE
 subprojects {
     apply from: JAVA_GRADLE
     apply from: SONAR_GRADLE
-    apply from: LICENSE_GRADLE
+    apply from: SPOTLESS_GRADLE
     apply from: PUBLISH_GRADLE
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'java-library'

--- a/codequality/HEADER
+++ b/codequality/HEADER
@@ -1,13 +1,15 @@
-Copyright 2016-${year} ${name}
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+/*
+ * Copyright 2016-$YEAR Sixhours
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/gradle/license.gradle
+++ b/gradle/license.gradle
@@ -1,9 +1,0 @@
-apply plugin: 'com.github.hierynomus.license'
-
-license {
-    header rootProject.file('codequality/HEADER')
-    ext.year = Calendar.getInstance().get(Calendar.YEAR)
-    ext.name = 'Sixhours'
-    mapping('java', 'SLASHSTAR_STYLE')
-    strictCheck true
-}

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'com.diffplug.spotless'
+
+spotless {
+    enforceCheck = false
+    java {
+        removeUnusedImports()
+        forbidWildcardImports()
+
+        licenseHeaderFile("$rootProject.projectDir/codequality/HEADER")
+    }
+}

--- a/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/SpyMemcachedClientTest.java
+++ b/memcached-spring-boot-autoconfigure/src/test/java/io/sixhours/memcached/cache/SpyMemcachedClientTest.java
@@ -25,7 +25,10 @@ import java.util.concurrent.ExecutionException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class SpyMemcachedClientTest {
 


### PR DESCRIPTION
The License Gradle Plugin depends on an older `spring-core` version that conflicts with Spring Boot 4, therefore these two plugins cannot be used together.

Replace License Gradle Plugin with Spotless for applying license headers and code formatting.

Resolves #185